### PR TITLE
Fixes #48

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -127,7 +127,9 @@ function mfNamesFromClass($class, $prefix = 'h-') {
 	$matches = array();
 
 	foreach ($classes as $classname) {
-		if (stristr(' ' . $classname, ' ' . $prefix) !== false) {
+		$compare_classname = strtolower(' ' . $classname);
+		$compare_prefix = strtolower(' ' . $prefix);
+		if (stristr($compare_classname, $compare_prefix) !== false && ($compare_classname != $compare_prefix)) {
 			$matches[] = ($prefix === 'h-') ? $classname : substr($classname, strlen($prefix));
 		}
 	}
@@ -150,7 +152,8 @@ function nestedMfPropertyNamesFromClass($class) {
 	
 	foreach (explode(' ', $class) as $classname) {
 		foreach ($prefixes as $prefix) {
-			if (stristr(' ' . $classname, $prefix)) {
+			$compare_classname = strtolower(' ' . $classname);
+			if (stristr($compare_classname, $prefix) && ($compare_classname != $prefix)) {
 				$propertyNames = array_merge($propertyNames, mfNamesFromClass($classname, ltrim($prefix)));
 			}
 		}

--- a/tests/Mf2/ParserTest.php
+++ b/tests/Mf2/ParserTest.php
@@ -201,4 +201,17 @@ EOT;
 		$this->assertNull($mf);
 		$this->assertContains('jpeg', $curlInfo['content_type']);
 	}
+
+	/**
+	 * @see https://github.com/indieweb/php-mf2/issues/48
+	 */
+	public function testIgnoreClassesEndingInHyphen() {
+		$input = '<span class="h-entry"> <span class="e-">foo</span> </span>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+		// print_r($output);
+
+		$this->assertArrayNotHasKey('0', $output['items'][0]['properties']);
+	}
+
 }


### PR DESCRIPTION
Tried my hand at fixing issue #48. As far as I can tell it should work.

I think the use of <code>strtolower</code> means we can use <code>strstr()</code> instead of <code>stristr()</code>, if desired.

I'm unclear why the extra spaces are added in the comparisons. Can someone explain that to me? (IRC is fine. :) 

Note: UrlTest::testReturnsUrlIfAbsolute was failing at the time I merged from upstream - and still is. I have not investigated how to fix it yet.
