### PR TITLE
No need to manually remove headers in fetch function (fixes issue#55)

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -78,8 +78,7 @@ function fetch($url, $convertClassic = true, &$curlInfo=null) {
 		return null;
 	}
 
-	$html = mb_substr($response, $info['header_size']);
-	return parse($html, $url, $convertClassic);
+	return parse($response, $url, $convertClassic);
 }
 
 /**


### PR DESCRIPTION
Having `CURLOPT_HEADER` set to `false` already removes the HTTP headers from the response, so we don't need to manually remove headers, we can just pass the response straight to the parse function.
