### PR TITLE
Added parse+tests for audio, video, and source elements.

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -442,7 +442,7 @@ class Parser {
 	public function parseU(\DOMElement $u) {
 		if (($u->tagName == 'a' or $u->tagName == 'area') and $u->getAttribute('href') !== null) {
 			$uValue = $u->getAttribute('href');
-		} elseif ($u->tagName == 'img' and $u->getAttribute('src') !== null) {
+		} elseif (in_array($u->tagName, array('img', 'audio', 'video', 'source')) and $u->getAttribute('src') !== null) {
 			$uValue = $u->getAttribute('src');
 		} elseif ($u->tagName == 'object' and $u->getAttribute('data') !== null) {
 			$uValue = $u->getAttribute('data');

--- a/tests/Mf2/ParseUTest.php
+++ b/tests/Mf2/ParseUTest.php
@@ -136,4 +136,43 @@ class ParseUTest extends PHPUnit_Framework_TestCase {
 		$result = Mf2\parse($input);
 		$this->assertEquals('http://example.com/right', $result['items'][0]['properties']['url'][0]);
 	}
+
+	/**
+	 * @group parseU
+	 */
+	public function testParseUHandlesAudio() {
+		$input = '<div class="h-entry"><audio class="u-audio" src="http://example.com/audio.mp3"></div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayHasKey('audio', $output['items'][0]['properties']);
+		$this->assertEquals('http://example.com/audio.mp3', $output['items'][0]['properties']['audio'][0]);
+	}
+
+	/**
+	 * @group parseU
+	 */
+	public function testParseUHandlesVideo() {
+		$input = '<div class="h-entry"><video class="u-video" src="http://example.com/video.mp4"></video></div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayHasKey('video', $output['items'][0]['properties']);
+		$this->assertEquals('http://example.com/video.mp4', $output['items'][0]['properties']['video'][0]);
+	}
+
+
+	/**
+	 * @group parseU
+	 */
+	public function testParseUHandlesSource() {
+		$input = '<div class="h-entry"><video><source class="u-video" src="http://example.com/video.mp4" type="video/mp4"><source class="u-video" src="http://example.com/video.ogg" type="video/ogg"></video></div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayHasKey('video', $output['items'][0]['properties']);
+		$this->assertEquals('http://example.com/video.mp4', $output['items'][0]['properties']['video'][0]);
+		$this->assertEquals('http://example.com/video.ogg', $output['items'][0]['properties']['video'][1]);
+	}
+
 }


### PR DESCRIPTION
Fixes #63, reference http://microformats.org/wiki/microformats-2-parsing#parsing_a_u-_property

Note: Test UrlTest::testReturnsUrlIfAbsolute was failing and continues to fail (PHP 5.4):

> Mf2\Parser\Test\UrlTest::testReturnsUrlIfAbsolute with data set #16 ('relative add scheme host user from base', 'http://user:@www.example.com', 'server.php', 'http://user:@www.example.com/server.php')
relative add scheme host user from base
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'http://user:@www.example.com/server.php'
+'http://user@www.example.com/server.php'

