### PR TITLE
Attempting to fix #70

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -672,7 +672,7 @@ class Parser {
 			// In most cases, the value attribute of the nested microformat should be the p- parsed value of the elemnt.
 			// The only times this is different is when the microformat is nested under certain prefixes, which are handled below.
 			$result['value'] = $this->parseP($subMF);
-
+			
 			// Does this µf have any property names other than h-*?
 			$properties = nestedMfPropertyNamesFromElement($subMF);
 
@@ -688,7 +688,7 @@ class Parser {
 						$prefixSpecificResult['html'] = $eParsedResult['html'];
 						$prefixSpecificResult['value'] = $eParsedResult['value'];
 					} elseif (in_array('u-', $prefixes)) {
-						$prefixSpecificResult['value'] = $this->parseU($subMF);
+						$prefixSpecificResult['value'] = (empty($result['properties']['url'])) ? $this->parseU($subMF) : reset($result['properties']['url']);
 					}
 					$return[$property][] = $prefixSpecificResult;
 				}

--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -672,7 +672,7 @@ class Parser {
 			// In most cases, the value attribute of the nested microformat should be the p- parsed value of the elemnt.
 			// The only times this is different is when the microformat is nested under certain prefixes, which are handled below.
 			$result['value'] = $this->parseP($subMF);
-			
+
 			// Does this µf have any property names other than h-*?
 			$properties = nestedMfPropertyNamesFromElement($subMF);
 

--- a/tests/Mf2/CombinedMicroformatsTest.php
+++ b/tests/Mf2/CombinedMicroformatsTest.php
@@ -255,8 +255,37 @@ class CombinedMicroformatsTest extends PHPUnit_Framework_TestCase {
 		    </li>
 		  </ul>
 		</div>';
-		$expected = '{"rels": [], "items": [{"type": ["h-entry"], "properties": {"content": [{"html": "Hello World", "value": "Hello World"}], "comment": [{"type": ["h-cite"], "properties": {"content": ["lol"], "url": ["http://example.org/post1234"], "published": ["2015-07-12 12:03"], "name": ["lol"], "author": [{"type": ["h-card"], "properties": {"url": ["http://jane.example.com/"], "name": ["Jane Bloggs"]}, "value": "http://jane.example.com/"}]}, "value": "http://example.org/post1234"}], "name": ["Name"]}}]}
-';
+		$expected = '{
+		  "items": [{
+    	  "type": ["h-entry"],
+	      "properties": {
+	        "name": ["Name"],
+	        "content": [{
+	          "html": "Hello World",
+	          "value": "Hello World"
+	        }],
+	        "comment": [{
+            "type": ["h-cite"],
+            "properties": {
+              "author": [{
+                "type": ["h-card"],
+                "properties": {
+                  "name": ["Jane Bloggs"],
+                  "url": ["http:\/\/jane.example.com\/"]
+                },
+                "value": "http:\/\/jane.example.com\/"
+              }],
+              "content": ["lol"],
+              "name": ["lol"],
+              "url": ["http:\/\/example.org\/post1234"],
+              "published": ["2015-07-12 12:03"]
+            },
+            "value": "http:\/\/example.org\/post1234"
+          }]
+	      }
+	    }],
+	    "rels":[]
+	  }';
 	  	$mf = Mf2\parse($input);
 
 		$this->assertJsonStringEqualsJsonString(json_encode($mf), $expected);

--- a/tests/Mf2/CombinedMicroformatsTest.php
+++ b/tests/Mf2/CombinedMicroformatsTest.php
@@ -255,41 +255,13 @@ class CombinedMicroformatsTest extends PHPUnit_Framework_TestCase {
 		    </li>
 		  </ul>
 		</div>';
-		$expected = '{
-		  "items": [{
-    	  "type": ["h-entry"],
-	      "properties": {
-	        "name": ["Name"],
-	        "content": [{
-	          "html": "Hello World",
-	          "value": "Hello World"
-	        }],
-	        "comment": [{
-            "type": ["h-cite"],
-            "properties": {
-              "author": [{
-                "type": ["h-card"],
-                "properties": {
-                  "name": ["Jane Bloggs"],
-                  "url": ["http:\/\/jane.example.com\/"]
-                },
-                "value": "http:\/\/jane.example.com\/"
-              }],
-              "content": ["lol"],
-              "name": ["lol"],
-              "url": ["http:\/\/example.org\/post1234"],
-              "published": ["2015-07-12 12:03"]
-            },
-            "value": "http:\/\/example.org\/post1234"
-          }]
-	      }
-	    }],
-	    "rels":{}
-	  }';
-		$parser = new Parser($input, '', true);
-		$output = $parser->parse();
+		$expected = '{"rels": [], "items": [{"type": ["h-entry"], "properties": {"content": [{"html": "Hello World", "value": "Hello World"}], "comment": [{"type": ["h-cite"], "properties": {"content": ["lol"], "url": ["http://example.org/post1234"], "published": ["2015-07-12 12:03"], "name": ["lol"], "author": [{"type": ["h-card"], "properties": {"url": ["http://jane.example.com/"], "name": ["Jane Bloggs"]}, "value": "http://jane.example.com/"}]}, "value": "http://example.org/post1234"}], "name": ["Name"]}}]}
+';
+	  	$mf = Mf2\parse($input);
 
-		$this->assertJsonStringEqualsJsonString(json_encode($output), $expected);
+		$this->assertJsonStringEqualsJsonString(json_encode($mf), $expected);
+		$this->assertEquals($mf['items'][0]['properties']['comment'][0]['value'], 'http://example.org/post1234');
+		$this->assertEquals($mf['items'][0]['properties']['comment'][0]['properties']['author'][0]['value'], 'http://jane.example.com/');
 	}
 	
 	public function testMicroformatsNestedUnderPPropertyClassnamesDeriveValueFromFirstPName() {


### PR DESCRIPTION
I modified the asserted JSON in two slight ways, neither of which are related to this test: 1) The date format had the "T" and the seconds 2) Changed the "rels" to [] instead of {}. These updates, in conjunction with the parser update, should fix issue #70.

I've also added two assertions for the implied URL values, which pass. 