### PR TITLE
Re-assign copyright to Barnaby Walters (from mistaken G5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-php-mf2
-=======
+# php-mf2
 
 [![Build Status](https://travis-ci.org/indieweb/php-mf2.png?branch=master)](http://travis-ci.org/indieweb/php-mf2)
 
@@ -418,7 +417,7 @@ Many thanks to @aaronpk, @gRegorLove and @kylewm for contributions, @aaronpk and
 
 ## License
 
-Copyright (c) 2013 G5
+Copyright (c) 2013 [Barnaby Walters](https://github.com/barnabywalters)
 
 MIT License
 


### PR DESCRIPTION
http://indiewebcamp.com/irc/2016-01-17#t1453060609337

***

kylewm BOT [11:56 AM] 
what is G5?


Loqi BOT [11:56 AM] 
It looks like we don't have a page for "G5" yet. Would you like to create it? https://indiewebcamp.com/s/10Ba


kylewm BOT [11:57 AM] 
asking because indieweb/php-mf2 is "Copyright (c) 2013 G5"


tantek BOT [11:57 AM] 
also: https://support.twitter.com/articles/20170082?lang=en "Your Promoted Trend name length cannot exceed ~20 characters. Since not every character is the same width, your actual character limit will vary."

[11:58] 
is that Barnaby's thingZ?

[11:58] 
s/thingZ/thing


Loqi BOT [11:58 AM] 
tantek meant to say: is that Barnaby's thing?


tantek BOT [12:00 PM] 
also interesting: https://moz.com/blog/how-hashtags-work-on-twitter-instagram-google-plus-pinterest-facebook-tumblr-and-flickr


kylewm BOT [12:00 PM] 
G5 is https://github.com/G5


Loqi BOT [12:00 PM] 
[[G5]] !N https://indiewebcamp.com/wiki/index.php?oldid=24642&rcid=24608 * Loqi.me * (+54) prompted by kylewm https://indiewebcamp.com/irc/2016-01-17/line/1453060609337 and dfn added by kylewm

[12:00] 
ok


kylewm BOT [12:00 PM] 
which does not appear to be a barnaby thing


tantek BOT [12:01 PM] 
ok that's odd

[12:02] 
nor is there anything "mf2" in their repos


kylewm BOT [12:02 PM] 
looks like it was copy/pasted from the Ruby parser


tantek BOT [12:02 PM] 
kylewm: possible name collision?


kylewm BOT [12:02 PM] 
which was under G5 until shaners moved it


tantek BOT [12:02 PM] 
but it's php?

[12:02] 
shaners, can you help with this?

***

Shane Becker [8:08 PM] 
tantek kylewm aaronpk: wrt G5 listed as the copyright on php-mf2 (somehow), should I just go ahead and change that to public domain / CC0 like the other things?

aaronpk [8:12 PM] 
I could have sworn it had a different license. Can you check the history?

Shane Becker [8:13 PM] 
sure

[8:14] 
https://github.com/indieweb/php-mf2/commit/7ceab6679021c18241d7d9b24c0d0ea7a68c075f#diff-04c6e90faac2675aa89e2176d2eec7d8

GitHub
Issue #72 , license not obvious. · indieweb/php-mf2@7ceab66 · GitHub
Previously the license was only referenced in the composer.json file. This does NOT change the license, this just makes it more obvious.

aaronpk [8:16 PM] 
lol oops

[8:16] 
Well then

[8:16] 
Change it to copyright Barnaby Walters then

[8:17] 
Since the license was already referenced in the composer.json file

Shane Becker [8:17 PM] 
Looks like ben_thatmustbeme added it by copy/pasta from the ruby one