### PR TITLE
Implemented @glennjones "innerText" parsing for better parsed whitespace

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -372,7 +372,7 @@ class Parser {
 
 		$excludeTags = array('noframe', 'noscript', 'script', 'style', 'frames', 'frameset');
 
-		if ( isset($el->tagName) )
+		if (isset($el->tagName))
 		{
 
 			if (in_array(strtolower($el->tagName), $excludeTags)) {
@@ -391,14 +391,12 @@ class Parser {
 				return $el->getAttribute('alt');
 			} else if ($el->tagName == 'abbr' and $el->getAttribute('title') !== '') {
 				return $el->getAttribute('title');
-			// } else if (in_array($el->tagName, array('data', 'input')) and $el->getAttribute('value') !== '') {
-				// return $el->getAttribute('value');
 			}
 
 		}
 
 		// if node is a text node get its text
-		if ( isset($el->nodeType) && $el->nodeType === 3) {
+		if (isset($el->nodeType) && $el->nodeType === 3) {
 			$out .= $el->textContent;
 		}
 
@@ -417,22 +415,22 @@ class Parser {
 			}
 		}
 
-		if ( isset($el->tagName) ) {
+		if (isset($el->tagName)) {
 
 			// if its a block level tag add an additional space at the end
-			if ( in_array(strtolower($el->tagName), $blockLevelTags) )
+			if (in_array(strtolower($el->tagName), $blockLevelTags))
 			{
 				$out .= ' ';
 			}
 			// else if its a br, replace with newline
-			else if ( strtolower($el->tagName) == 'br')
+			else if (strtolower($el->tagName) == 'br')
 			{
 				$out .= "\n";
 			}
 
 		} 
 
-		return ( $out === '' ) ? NULL : $out;
+		return ($out === '') ? NULL : $out;
 	}
 
 	// TODO: figure out if this has problems with sms: and geo: URLs
@@ -508,9 +506,6 @@ class Parser {
 		}
 
 		$this->resolveChildUrls($p);
-
-		// $pValue = unicodeTrim($this->innerText($p));
-		// return $pValue;
 		
 		if ($p->tagName == 'img' and $p->getAttribute('alt') !== '') {
 			$pValue = $p->getAttribute('alt');
@@ -522,11 +517,9 @@ class Parser {
 			$pValue = $p->getAttribute('value');
 		} else {
 			$pValue = unicodeTrim($this->innerText($p));
-			// $pValue = unicodeTrim($this->textContent($p));
 		}
 
 		return $pValue;
-		
 	}
 
 	/**

--- a/tests/Mf2/ParsePTest.php
+++ b/tests/Mf2/ParsePTest.php
@@ -102,4 +102,17 @@ EOT;
 		$this->assertEquals('Blah blah http://waterpigs.co.uk/photos/five-legged-elephant.jpg', $result['items'][0]['properties']['summary'][0]);
 	}
 
+	/**
+	 * @see https://github.com/indieweb/php-mf2/issues/69
+	 */
+	public function testBrWhitespaceIssue69() {
+		$input = '<div class="h-card"><p class="p-adr"><span class="p-street-address">Street Name 9</span><br/><span class="p-locality">12345 NY, USA</span></p></div>';
+		$result = Mf2\parse($input);
+
+		$this->assertEquals('Street Name 9' . "\n" . '12345 NY, USA', $result['items'][0]['properties']['adr'][0]);
+		$this->assertEquals('Street Name 9', $result['items'][0]['properties']['street-address'][0]);
+		$this->assertEquals('12345 NY, USA', $result['items'][0]['properties']['locality'][0]);
+		$this->assertEquals('Street Name 9' . "\n" . '12345 NY, USA', $result['items'][0]['properties']['name'][0]);
+	}
+
 }

--- a/tests/Mf2/ParserTest.php
+++ b/tests/Mf2/ParserTest.php
@@ -286,7 +286,7 @@ EOT;
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
-		$this->assertEquals('', $output['items'][0]['properties']['name'][0]);
+		$this->assertEquals('Person Bee', $output['items'][0]['properties']['name'][0]);
 		$this->assertEquals('rect', $output['items'][0]['properties']['category'][0]['shape']);
 		$this->assertEquals('100,100,120,120', $output['items'][0]['properties']['category'][0]['coords']);
 		$this->assertEquals('Person Bee', $output['items'][0]['properties']['category'][0]['value']);


### PR DESCRIPTION
This should solve #69 and most cases like it. I added this as a separate, recursive method `innerText()` because I wasn't sure about unintended consequences of trying to expand the `textContent()` method, used in multiple places. 

Also updated test `ParserTest::testAreaTag()` with what I believe is the correct assertion. Previously it asserted the parsed name would be blank, but it currently (correctly, I believe) parses "Person Bee"

Test `UrlTest::testReturnsUrlIfAbsolute` continues to fail as before; unrelated to this PR.