### PR TITLE
strip script and style tags from parsed html

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -715,6 +715,9 @@ class Parser {
 		// TODO: as it is this is not relative to only children, make this .// and rerun tests
 		$this->resolveChildUrls($e);
 
+		$this->removeTags($e, 'script');
+		$this->removeTags($e, 'style');
+
 		$html = '';
 		foreach ($e->childNodes as $node) {
 			$html .= $node->C14N();
@@ -722,8 +725,14 @@ class Parser {
 
 		return array(
 			'html' => $html,
-			'value' => unicodeTrim($this->textContent($e))
+			'value' => unicodeTrim($this->innerText($e))
 		);
+	}
+
+	private function removeTags(\DOMElement &$e, $tagName) {
+		while(($r = $e->getElementsByTagName($tagName)) && $r->length) {
+			$r->item(0)->parentNode->removeChild($r->item(0));
+		}
 	}
 
 	/**

--- a/tests/Mf2/ParserTest.php
+++ b/tests/Mf2/ParserTest.php
@@ -314,4 +314,45 @@ EOT;
 		$this->assertArrayHasKey('url', $output['items'][0]['properties']['category'][0]['properties']);
 		$this->assertEquals('http://b.example.com/', $output['items'][0]['properties']['category'][0]['properties']['url'][0]);
 	}
+
+	public function testScriptTagContentsRemovedFromTextValue() {
+		$input = <<<EOT
+<div class="h-entry">
+	<div class="p-content">
+		<b>Hello World</b>
+		<script>alert("hi");</script>
+	</div>
+</div>
+EOT;
+
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertContains('h-entry', $output['items'][0]['type']);
+		$this->assertContains('Hello World', $output['items'][0]['properties']['content'][0]);
+		$this->assertNotContains('alert', $output['items'][0]['properties']['content'][0]);
+	}
+
+	public function testScriptTagContentsRemovedFromHTMLValue() {
+		$input = <<<EOT
+<div class="h-entry">
+	<div class="e-content">
+		<b>Hello World</b>
+		<script>alert("hi");</script>
+	</div>
+</div>
+EOT;
+
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertContains('h-entry', $output['items'][0]['type']);
+		$this->assertContains('Hello World', $output['items'][0]['properties']['content'][0]['value']);
+		$this->assertContains('<b>Hello World</b>', $output['items'][0]['properties']['content'][0]['html']);
+		# The script tag and its contents should be present in the HTML returned
+		$this->assertContains('<script>alert("hi");</script>', $output['items'][0]['properties']['content'][0]['html']);
+		# The contents of the script tag should not be present in the plaintext "value" of the content
+		$this->assertNotContains('alert', $output['items'][0]['properties']['content'][0]['value']);
+	}
+
 }

--- a/tests/Mf2/ParserTest.php
+++ b/tests/Mf2/ParserTest.php
@@ -339,6 +339,11 @@ EOT;
 	<div class="e-content">
 		<b>Hello World</b>
 		<script>alert("hi");</script>
+		<style>body{ visibility: hidden; }</style>
+		<p>
+			<script>alert("hi");</script>
+			<style>body{ visibility: hidden; }</style>
+		</p>
 	</div>
 </div>
 EOT;
@@ -349,10 +354,11 @@ EOT;
 		$this->assertContains('h-entry', $output['items'][0]['type']);
 		$this->assertContains('Hello World', $output['items'][0]['properties']['content'][0]['value']);
 		$this->assertContains('<b>Hello World</b>', $output['items'][0]['properties']['content'][0]['html']);
-		# The script tag and its contents should be present in the HTML returned
-		$this->assertContains('<script>alert("hi");</script>', $output['items'][0]['properties']['content'][0]['html']);
-		# The contents of the script tag should not be present in the plaintext "value" of the content
+		# The script and style tags should be removed from both HTML and plaintext results
+		$this->assertNotContains('alert', $output['items'][0]['properties']['content'][0]['html']);
 		$this->assertNotContains('alert', $output['items'][0]['properties']['content'][0]['value']);
+		$this->assertNotContains('visibility', $output['items'][0]['properties']['content'][0]['html']);
+		$this->assertNotContains('visibility', $output['items'][0]['properties']['content'][0]['value']);
 	}
 
 }

--- a/tests/Mf2/URLTest.php
+++ b/tests/Mf2/URLTest.php
@@ -212,9 +212,6 @@ class UrlTest extends PHPUnit_Framework_TestCase {
 			array('relative add host from base',
 				'http://www.example.com', 'server.php', 'http://www.example.com/server.php'),
 
-			array('relative add scheme host user from base',
-				'http://user:@www.example.com', 'server.php', 'http://user:@www.example.com/server.php'),
-
 			array('relative add scheme host pass from base',
 				'http://:pass@www.example.com', 'server.php', 'http://:pass@www.example.com/server.php'),
 
@@ -255,6 +252,15 @@ class UrlTest extends PHPUnit_Framework_TestCase {
 				'http://example.com:8080/index.html', '/photo.jpg', 'http://example.com:8080/photo.jpg')
 
 		);
+
+		// PHP 5.4 and before returns a different result, but either are acceptable
+		if(PHP_MAJOR_VERSION <= 5 && PHP_MINOR_VERSION <= 4) {
+			$cases[] = array('relative add scheme host user from base',
+				'http://user:@www.example.com', 'server.php', 'http://user@www.example.com/server.php');
+		} else {
+			$cases[] = array('relative add scheme host user from base',
+				'http://user:@www.example.com', 'server.php', 'http://user:@www.example.com/server.php');
+		}
 
 		// Test cases from RFC
 		// http://tools.ietf.org/html/rfc3986#section-5.4


### PR DESCRIPTION
* currently the contents of the &lt;script&gt; tag is present in the plaintext "value" of a property parsed from an `e-` class. adds failing test to demonstrate that.
* removes script and style tags before parsing http://microformats.org/wiki/microformats2-parsing-issues#exclude_style_elements_before_parsing
* fixes the URL resolving test in 5.4 by accepting that result
