### PR TITLE
add failing test and fix for #91

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -1025,7 +1025,7 @@ class Parser {
 		$alternates = array();
 
 		// Iterate through all a, area and link elements with rel attributes
-		foreach ($this->xpath->query('//*[@rel and @href]') as $hyperlink) {
+		foreach ($this->xpath->query('//a[@rel and @href] | //link[@rel and @href] | //area[@rel and @href]') as $hyperlink) {
 			if ($hyperlink->getAttribute('rel') == '')
 				continue;
 

--- a/tests/Mf2/RelTest.php
+++ b/tests/Mf2/RelTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Tests of the parsing methods within mf2\Parser
+ */
+
+namespace Mf2\Parser\Test;
+
+use Mf2;
+use Mf2\Parser;
+use PHPUnit_Framework_TestCase;
+
+class RelTest extends PHPUnit_Framework_TestCase {
+  public function setUp() {
+    date_default_timezone_set('Europe/London');
+  }
+
+  public function testRelValueOnLinkTag() {
+    $input = '<link rel="webmention" href="http://example.com/webmention">';
+    $parser = new Parser($input);
+    $output = $parser->parse();
+
+    $this->assertArrayHasKey('webmention', $output['rels']);
+    $this->assertEquals('http://example.com/webmention', $output['rels']['webmention'][0]);
+  }
+
+  public function testRelValueOnATag() {
+    $input = '<a rel="webmention" href="http://example.com/webmention">webmention me</a>';
+    $parser = new Parser($input);
+    $output = $parser->parse();
+
+    $this->assertArrayHasKey('webmention', $output['rels']);
+    $this->assertEquals('http://example.com/webmention', $output['rels']['webmention'][0]);
+  }
+
+  public function testRelValueOnAreaTag() {
+    $input = '<map><area rel="webmention" href="http://example.com/webmention"/></map>';
+    $parser = new Parser($input);
+    $output = $parser->parse();
+
+    $this->assertArrayHasKey('webmention', $output['rels']);
+    $this->assertEquals('http://example.com/webmention', $output['rels']['webmention'][0]);
+  }
+
+  public function testRelValueOnBTag() {
+    $input = '<b rel="webmention" href="http://example.com/webmention">this makes no sense</b>';
+    $parser = new Parser($input);
+    $output = $parser->parse();
+
+    $this->assertArrayNotHasKey('webmention', $output['rels']);
+  }
+
+}

--- a/tests/Mf2/RelTest.php
+++ b/tests/Mf2/RelTest.php
@@ -41,6 +41,51 @@ class RelTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals('http://example.com/webmention', $output['rels']['webmention'][0]);
   }
 
+  public function testRelValueOrder() {
+    $input = '<map><area rel="webmention" href="http://example.com/area"/></map>
+      <a rel="webmention" href="http://example.com/a">webmention me</a>
+      <link rel="webmention" href="http://example.com/link">';
+    $parser = new Parser($input);
+    $output = $parser->parse();
+
+    $this->assertArrayHasKey('webmention', $output['rels']);
+    $this->assertEquals('http://example.com/area', $output['rels']['webmention'][0]);
+    $this->assertEquals('http://example.com/a', $output['rels']['webmention'][1]);
+    $this->assertEquals('http://example.com/link', $output['rels']['webmention'][2]);
+  }
+
+  public function testRelValueOrder2() {
+    $input = '<map><area rel="webmention" href="http://example.com/area"/></map>
+      <link rel="webmention" href="http://example.com/link">
+      <a rel="webmention" href="http://example.com/a">webmention me</a>';
+    $parser = new Parser($input);
+    $output = $parser->parse();
+
+    $this->assertArrayHasKey('webmention', $output['rels']);
+    $this->assertEquals('http://example.com/area', $output['rels']['webmention'][0]);
+    $this->assertEquals('http://example.com/link', $output['rels']['webmention'][1]);
+    $this->assertEquals('http://example.com/a', $output['rels']['webmention'][2]);
+  }
+
+  public function testRelValueOrder3() {
+    $input = '<html>
+      <head>
+        <link rel="webmention" href="http://example.com/link">
+      </head>
+      <body>
+        <a rel="webmention" href="http://example.com/a">webmention me</a>
+        <map><area rel="webmention" href="http://example.com/area"/></map>
+      </body>
+    </html>';
+    $parser = new Parser($input);
+    $output = $parser->parse();
+
+    $this->assertArrayHasKey('webmention', $output['rels']);
+    $this->assertEquals('http://example.com/link', $output['rels']['webmention'][0]);
+    $this->assertEquals('http://example.com/a', $output['rels']['webmention'][1]);
+    $this->assertEquals('http://example.com/area', $output['rels']['webmention'][2]);
+  }
+
   public function testRelValueOnBTag() {
     $input = '<b rel="webmention" href="http://example.com/webmention">this makes no sense</b>';
     $parser = new Parser($input);


### PR DESCRIPTION
only looks on `a`,`link`, and `area` for rel attributes, since these are the only elements that HTML allows to have the rel attribute.