### PR TITLE
when parsing e-content, output result as HTML instead of XML

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -736,7 +736,7 @@ class Parser {
 
 		$html = '';
 		foreach ($e->childNodes as $node) {
-			$html .= $node->C14N();
+			$html .= $node->ownerDocument->saveHTML($node);
 		}
 
 		return array(

--- a/tests/Mf2/ParserTest.php
+++ b/tests/Mf2/ParserTest.php
@@ -92,8 +92,18 @@ class ParserTest extends PHPUnit_Framework_TestCase {
 		$parser = new Parser($input, 'http://example.com');
 		$output = $parser->parse();
 
-		$this->assertEquals('Blah blah <a href="http://example.com/a-url">thing</a>. <object data="http://example.com/object"></object> <img src="http://example.com/img"></img>', $output['items'][0]['properties']['content'][0]['html']);
+		$this->assertEquals('Blah blah <a href="http://example.com/a-url">thing</a>. <object data="http://example.com/object"></object> <img src="http://example.com/img">', $output['items'][0]['properties']['content'][0]['html']);
 		$this->assertEquals('Blah blah thing.  http://example.com/img', $output['items'][0]['properties']['content'][0]['value']);
+	}
+
+	public function testParseEWithBR() {
+		$input = '<div class="h-entry"><div class="e-content">Here is content with two lines.<br>The br tag should not be converted to an XML br/br element.</div></div>';
+		//$parser = new Parser($input);
+		$output = Mf2\parse($input);
+
+		$this->assertArrayHasKey('content', $output['items'][0]['properties']);
+		$this->assertEquals('Here is content with two lines.<br>The br tag should not be converted to an XML br/br element.', $output['items'][0]['properties']['content'][0]['html']);
+		$this->assertEquals('Here is content with two lines.'."\n".'The br tag should not be converted to an XML br/br element.', $output['items'][0]['properties']['content'][0]['value']);
 	}
 
 	/**


### PR DESCRIPTION
* adds failing test for parsing `one<br>two` (currently converts it to `one<br></br>two`
* fixes parser by using saveHTML instead of C14N