### PR TITLE
Updated test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Pull requests very welcome, please try to maintain stylistic, structural and nam
 4. Run PHPUnit with `./vendor/bin/phpunit`
 5. Make your changes
 6. Add PHPUnit tests for your changes, either in an existing test file if suitable, or a new one
-7. Make sure your tests pass (`./vendor/bin/phpunit`), preferably using both PHP 5.3 and 5.4
+7. Make sure your tests pass (`./vendor/bin/phpunit`), using 5.4+
 8. Go to your fork of the repo on github.com and make a pull request, preferably with a short summary, detailed description and references to issues/parsing specs as appropriate
 9. Bask in the warm feeling of having contributed to a piece of free software
 
@@ -274,7 +274,7 @@ Pull requests very welcome, please try to maintain stylistic, structural and nam
 
 There are currently two separate test suites: one, in `tests/Mf2`, is written in phpunit, containing many microformats parsing examples as well as internal parser tests and regression tests for specific issues over php-mf2’s history. Run it with `./vendor/bin/phpunit`.
 
-The other, in `tests/test-suite`, is a custom test harness which hooks up php-mf2 to the cross-platform microformats test suite. Each test consists of a HTML file and a corresponding JSON file, and the suite can be run with `php ./tests/test-suite/test-suite.php`.
+The other, in `tests/test-suite`, is a custom test harness which hooks up php-mf2 to the cross-platform [microformats test suite](https://github.com/microformats/tests). To run these tests you must first install the tests with `./composer.phar install`. Each test consists of a HTML file and a corresponding JSON file, and the suite can be run with `php ./tests/test-suite/test-suite.php`.
 
 Currently php-mf2 passes the majority of it’s own test case, and a good percentage of the cross-platform tests. Contributors should ALWAYS test against the PHPUnit suite to ensure any changes don’t negatively impact php-mf2, and SHOULD run the cross-platform suite, especially if you’re changing parsing behaviour.
 

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,16 @@
             "homepage": "http://waterpigs.co.uk"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/microformats/tests"
+        }
+    ],
     "bin": ["bin/fetch-mf2", "bin/parse-mf2"],
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.4.0",
+        "microformats/test": "@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"

--- a/composer.lock
+++ b/composer.lock
@@ -1,11 +1,35 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4ddb858a7bdae5163307bd104589bd95",
-    "packages": [],
+    "hash": "a5f1918b014bb2cd3edbe1e47beea8ee",
+    "content-hash": "dc472478b9bbc26ff713fdb5b8d1df42",
+    "packages": [
+        {
+            "name": "microformats/test",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/microformats/tests.git",
+                "reference": "17d31dbeb3d64426d5a15548ea778f61df73c28f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/microformats/tests/zipball/17d31dbeb3d64426d5a15548ea778f61df73c28f",
+                "reference": "17d31dbeb3d64426d5a15548ea778f61df73c28f",
+                "shasum": ""
+            },
+            "type": "library",
+            "description": "Microformats test suite",
+            "support": {
+                "source": "https://github.com/microformats/tests/tree/master",
+                "issues": "https://github.com/microformats/tests/issues"
+            },
+            "time": "2016-05-25 09:22:18"
+        }
+    ],
     "packages-dev": [
         {
             "name": "phpunit/php-code-coverage",
@@ -70,16 +94,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.0",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "a923bb15680d0089e2316f7a4af8f437046e96bb"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a923bb15680d0089e2316f7a4af8f437046e96bb",
-                "reference": "a923bb15680d0089e2316f7a4af8f437046e96bb",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -113,20 +137,20 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-04-02 05:19:05"
+            "time": "2016-10-03 07:40:28"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a"
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
-                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
                 "shasum": ""
             },
             "require": {
@@ -135,20 +159,17 @@
             "type": "library",
             "autoload": {
                 "classmap": [
-                    "Text/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -157,35 +178,35 @@
             "keywords": [
                 "template"
             ],
-            "time": "2014-01-30 17:20:04"
+            "time": "2015-06-21 13:50:34"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.5",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c"
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
-                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "require-dev": {
+                "phpunit/phpunit": "~4|~5"
+            },
             "type": "library",
             "autoload": {
                 "classmap": [
-                    "PHP/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
@@ -201,7 +222,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2013-08-02 07:42:54"
+            "time": "2016-05-12 18:03:57"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -377,35 +398,34 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.6.6",
-            "target-dir": "Symfony/Component/Yaml",
+            "version": "v2.8.15",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Yaml.git",
-                "reference": "174f009ed36379a801109955fc5a71a49fe62dd4"
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "befb26a3713c97af90d25dd12e75621ef14d91ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/174f009ed36379a801109955fc5a71a49fe62dd4",
-                "reference": "174f009ed36379a801109955fc5a71a49fe62dd4",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/befb26a3713c97af90d25dd12e75621ef14d91ff",
+                "reference": "befb26a3713c97af90d25dd12e75621ef14d91ff",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
+                "php": ">=5.3.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Yaml\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -413,26 +433,28 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Yaml Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-03-30 15:54:10"
+            "homepage": "https://symfony.com",
+            "time": "2016-11-14 16:15:57"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "microformats/test": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.0"
+        "php": ">=5.4.0"
     },
     "platform-dev": []
 }

--- a/tests/test-suite/test-suite.php
+++ b/tests/test-suite/test-suite.php
@@ -1,18 +1,22 @@
 <?php
 
 /**
- * php-mf2 test suite
- * CLI usage from the tests/test-suite/ directory: php test-suite.php
- * @see https://github.com/tobiastom/tests
+ * microformats test suite for php-mf2
+ * 
+ * Before running this test suite, ensure that you run composer install
+ * to install the microformats/tests repository of tests.
+ * @see https://github.com/microformats/tests
  *
- * This will look through the specified directory for suite.json files
- * that represent a suite of tests. Then, for each suite the sub-directories
- * will be parsed for input.html, output.json, and test.json files. Each
- * test will then be executed. If a test fails, a message is displayed along
- * with the parsed output (array format) and the expected output (array format).
+ * CLI usage from library root directory: php ./tests/test-suite/test-suite.php
  *
- * Individual test suites may be run by calling TestSuite->runSuite($path)
- * where $path is the file path to the suite.json file.
+ * This will look through the test directories for .html files that
+ * represent a test and the corresponding .json file that represent
+ * the expected output. If a test fails, a message is displayed along
+ * with the parsed output and the expected output, both in array format.
+ *
+ * Individual test suites may be run by specifying the relative path within the repo.
+ * For example, to run only the 'microformats-v2' tests: 
+ *   php ./tests/test-suite/test-suite.php microformats-v2
  */
 
 namespace Mf2\Parser\TestSuite;
@@ -20,6 +24,7 @@ namespace Mf2\Parser\TestSuite;
 use Mf2\Parser;
 use Mf2;
 
+error_reporting(E_ALL);
 require dirname(__DIR__) . '/../vendor/autoload.php';
 
 class TestSuite
@@ -39,8 +44,16 @@ class TestSuite
 	 * @param string $path: path to test-suite-data 
 	 * @access public
 	 */
-	public function __construct($path = './test-suite-data/')
+	public function __construct($path = '')
 	{
+		$path = './vendor/microformats/test/tests/' . $path;
+
+		if ( !file_exists($path) )
+		{
+			echo sprintf('Specified path was not found: %s', $path), "\n";
+			exit;
+		}
+
 		$this->path = $path;
 	} # end method __construct()
 
@@ -53,14 +66,13 @@ class TestSuite
 	 */
 	public function start()
 	{
-		$directory = new \RecursiveDirectoryIterator($this->path);
+		$directory = new \RecursiveDirectoryIterator($this->path, \RecursiveDirectoryIterator::SKIP_DOTS);
 		$iterator = new \RecursiveIteratorIterator($directory);
-		$this->suites = new \RegexIterator($iterator, '/^.+suite\.json$/i', \RecursiveRegexIterator::GET_MATCH);
+		$this->suites = new \RegexIterator($iterator, '/^.+\.html$/i', \RecursiveRegexIterator::GET_MATCH);
 
 		foreach ( $this->suites as $suite )
 		{
-			$this->runSuite(reset($suite));
-			// echo "\n";
+			$this->runTest(reset($suite));
 		}
 
 		echo sprintf('Total tests: %d', $this->tests_total), "\n";
@@ -72,6 +84,115 @@ class TestSuite
 
 
 	/**
+	 * This method handles running a test
+	 * @param string $path: path to the test's HTML file
+	 * @access public
+	 * @return bool
+	 */
+	public function runTest($path)
+	{
+		$test_name = basename($path, '.html');
+		echo sprintf('Running test: %s.', $test_name), "\n";
+
+		$dirname = dirname($path);
+		$json_file = $dirname . '/' . $test_name . '.json';
+
+		if ( !file_exists($json_file) )
+		{
+			echo sprintf('Halting test: %s. No json file found.', $test_name), "\n";
+			return FALSE;
+		}
+
+		$input = file_get_contents($path);
+		$expected_output = json_decode(file_get_contents($json_file), TRUE);
+
+		$parser = new Parser($input, '', TRUE);
+		$output = $parser->parse(TRUE);
+
+		$test_differences = $this->array_diff_assoc_recursive($expected_output, $output);
+
+		# if: test passed
+		if ( empty($test_differences) )
+		{
+			$this->tests_passed++;
+		}
+		# else: test failed
+		else
+		{
+			echo sprintf('Test failed: %s', $test_name), "\n\n";
+			echo sprintf('Parsed: %s', print_r($output, TRUE)), "\n";
+			echo sprintf('Expected: %s', print_r($expected_output, TRUE)), "\n";
+			echo sprintf('Differences: %s', print_r($test_differences, TRUE)), "\n";
+			$this->tests_failed++;
+		} # end if
+
+		return TRUE;
+	} # end method runTest()
+
+
+	/**
+	 * This method recursively compares two arrays and returns the difference
+	 * @see http://us2.php.net/manual/en/function.array-diff-assoc.php
+	 * @param array $array1
+	 * @param array $array2
+	 * @access public
+	 * @return array
+	 */
+	public function array_diff_assoc_recursive($array1, $array2, $canonicalize = true)
+	{
+		$difference = array();
+
+		# loop: each key in first array
+		foreach ( $array1 as $key => $value )
+		{
+
+			# if: nested array
+			if ( is_array($value) )
+			{
+
+				# if: mis-match
+				if ( !isset($array2[$key]) || !is_array($array2[$key]) )
+				{
+					$difference[$key] = $value;
+				}
+				# else: recursive
+				else
+				{
+					$recursive_diff = $this->array_diff_assoc_recursive($value, $array2[$key]);
+
+					if ( !empty($recursive_diff) )
+					{
+						$difference[$key] = $recursive_diff;
+					}
+						
+				}
+
+			}
+			# else if: numeric key, non-array value
+			else if ( is_numeric($key) && !is_array($value) )
+			{
+
+				# if: check for value anywhere in second array (JSON is orderless)
+				if ( !in_array($value, $array2) )
+				{
+					$difference[$key] = $value;
+				}
+
+			}
+			# else if: associative key
+			else if ( !array_key_exists($key, $array2) || $array2[$key] !== $value )
+			{
+				$difference[$key] = $value;
+			}
+
+		} # end loop
+
+		return $difference;
+	} # end method array_diff_assoc_recursive()
+
+
+	/**
+	 * DEPRECATED
 	 * This method handles running a test suite
 	 * @param string $path: path to the suite's JSON file 
 	 * @access public
@@ -126,8 +247,6 @@ class TestSuite
 
 }
 
-$TestSuite = new TestSuite();
-$TestSuite->start(); # run all test suites
-
-// Alternately, run a specific suite
-// $TestSuite->runSuite('./test-suite-data/adr/suite.json');
+$path = ( empty($argv[1]) ) ? '' : $argv[1];
+$TestSuite = new TestSuite($path);
+$TestSuite->start(); # run tests


### PR DESCRIPTION
This updates the test suite to be included via Composer so we can more easily keep it up to date with https://github.com/microformats/tests, per #50.

The comparison of parsed mf2 to expected output now compares the complete array, not just the 'items' key. I took a stab at better array comparison, since the === comparison expects the array indexes to be in the same order. 

Unfortunately these changes bring the number of passing tests to zero, but hopefully a lot of those are minor. For example, I know that php-mf2 puts the "T" separator in parsed dt- values, but the test suite expected output does not ([see discussion](http://microformats.org/wiki/microformats2-parsing-issues#parsing_a_dt-_property)), so most date values will have that discrepancy.

The updated array comparison _should_ verify that every value in the expected output appears in the parsed output, but does not account for the parsed output having _more_ than the expected output. The array comparison could be run twice (switching the array parameters) but I wasn't sure if that was desired. And I thought it was more important to make sure the parser returns at least the expected output.
