### PR TITLE
Implied photo

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -951,25 +951,13 @@ class Parser {
 
 		// Check for u-photo
 		if (!array_key_exists('photo', $return)) {
-			// Look for img @src
-			try {
-				if ($e->tagName == 'img')
-					throw new Exception($e->getAttribute('src'));
 
-				// Look for nested img @src
-				foreach ($this->xpath->query('./img[count(preceding-sibling::*)+count(following-sibling::*)=0]', $e) as $em) {
-					if ($em->getAttribute('src') != '')
-						throw new Exception($em->getAttribute('src'));
-				}
+			$photo = $this->parseImpliedPhoto($e);
 
-				// Look for double nested img @src
-				foreach ($this->xpath->query('./*[count(preceding-sibling::*)+count(following-sibling::*)=0]/img[count(preceding-sibling::*)+count(following-sibling::*)=0]', $e) as $em) {
-					if ($em->getAttribute('src') != '')
-						throw new Exception($em->getAttribute('src'));
-				}
-			} catch (Exception $exc) {
-				$return['photo'][] = $this->resolveUrl($exc->getMessage());
+			if ($photo !== false) {
+				$return['photo'][] = $this->resolveUrl($photo);
 			}
+
 		}
 
 		// Check for u-url
@@ -1021,6 +1009,50 @@ class Parser {
 			$parsed['children'] = array_values(array_filter($children));
 		}
 		return $parsed;
+	}
+
+	/**
+	 * @see http://microformats.org/wiki/microformats2-parsing#parsing_for_implied_properties
+	 */
+	public function parseImpliedPhoto(\DOMElement $e) {
+
+		if ($e->tagName == 'img') {
+			return $e->getAttribute('src');
+		}
+
+		if ($e->tagName == 'object' && $e->hasAttribute('data')) {
+			return $e->getAttribute('data');
+		}
+
+		$xpaths = array(
+			'./img',
+			'./object',
+			'./*[count(preceding-sibling::*)+count(following-sibling::*)=0]/img',
+			'./*[count(preceding-sibling::*)+count(following-sibling::*)=0]/object',
+		);
+
+		foreach ($xpaths as $path) {
+			$els = $this->xpath->query($path, $e);
+
+			if ($els->length == 1) {
+				$el = $els->item(0);
+				$hClasses = mfNamesFromElement($el, 'h-');
+
+				// no nested h-
+				if (empty($hClasses)) {
+
+					if ($el->tagName == 'img') {
+						return $el->getAttribute('src');
+					} else if ($el->tagName == 'object' && $el->getAttribute('data') != '') {
+						return $el->getAttribute('data');
+					}
+
+				} // no nested h-
+			}
+		}
+
+		// no implied photo
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Added failing tests and fix for #88.

This adds support for parsing the photo from `object[data]` and also corrects the parsing for nested elements. Previously it wouldn't parse if the nested element had siblings (which may have been correct at the time); now it checks for `:only-of-type` among the siblings. I commented out the two tests that I believe were incorrect and re-wrote them.

Initially I wrote this as part of the `try...catch` code that existed already. I found I was repeating basically the same code for each parse attempt, so figured I would make it a separate method that loops through the xpaths. I hope that's not too bold of me. I can put it back in the `try...catch` if desired.
