### PR TITLE
Use longer array syntax for backcompat

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -353,7 +353,7 @@ class Parser {
 			if ($child->hasAttribute('src'))
 				$child->setAttribute('src', $this->resolveUrl($child->getAttribute('src')));
 			if ($child->hasAttribute('srcset'))
-				$child->setAttribute('srcset', applySrcsetUrlTransformation($child->getAttribute('href'), [$this, 'resolveUrl']));
+				$child->setAttribute('srcset', applySrcsetUrlTransformation($child->getAttribute('href'), array($this, 'resolveUrl')));
 			if ($child->hasAttribute('data'))
 				$child->setAttribute('data', $this->resolveUrl($child->getAttribute('data')));
 		}


### PR DESCRIPTION
Minimum PHP version in Composer remains PHP 5.4+, but using the longer array syntax ensures php-mf2 can still work in PHP 5.3 environments (for now), like some WordPress installs.

Fixes #101.