### PR TITLE
Fix parsing of "value" for nested microformats when not a property

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -865,10 +865,6 @@ class Parser {
 				continue;
 			}
 
-			// In most cases, the value attribute of the nested microformat should be the p- parsed value of the elemnt.
-			// The only times this is different is when the microformat is nested under certain prefixes, which are handled below.
-			$result['value'] = $this->parseP($subMF);
-
 			// Does this µf have any property names other than h-*?
 			$properties = nestedMfPropertyNamesFromElement($subMF);
 

--- a/tests/Mf2/CombinedMicroformatsTest.php
+++ b/tests/Mf2/CombinedMicroformatsTest.php
@@ -195,8 +195,7 @@ class CombinedMicroformatsTest extends PHPUnit_Framework_TestCase {
 			"properties": {
 				"name": ["Mozilla Foundation"],
 				"url": ["http://mozilla.org/"]
-			},
-			"value": "Mozilla Foundation"
+			}
 		}]
 	}]
 }';
@@ -230,6 +229,9 @@ class CombinedMicroformatsTest extends PHPUnit_Framework_TestCase {
 		$input = '<div class="h-entry"><div class="h-card e-content"><p>Hello</p></div></div>';
 		$mf = Mf2\parse($input);
 		
+		$this->assertArrayHasKey('value', $mf['items'][0]['properties']['content'][0]);
+		$this->assertEquals($mf['items'][0]['properties']['content'][0]['value'], 'Hello');
+		$this->assertArrayHasKey('html', $mf['items'][0]['properties']['content'][0]);
 		$this->assertEquals($mf['items'][0]['properties']['content'][0]['html'], '<p>Hello</p>');
 	}
 	
@@ -299,4 +301,19 @@ class CombinedMicroformatsTest extends PHPUnit_Framework_TestCase {
 		
 		$this->assertEquals($mf['items'][0]['properties']['author'][0]['value'], 'Zoe');
 	}
+
+
+	/**
+	 * @see https://github.com/indieweb/php-mf2/issues/98
+	 * @see https://github.com/microformats/tests/issues/58
+	 */
+	public function testNoValueForNestedMicroformatWithoutProperty() {
+		$input = '<div class="h-card" ><a class="h-card" href="jane.html">Jane Doe</a><p></p></div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+		
+		$this->assertArrayHasKey('children', $output['items'][0]);
+		$this->assertArrayNotHasKey('value', $output['items'][0]['children'][0]);
+	}
+
 }


### PR DESCRIPTION
Fixes #98 