### PR TITLE
Fixes for elements with missing attributes (#118)

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -588,13 +588,13 @@ class Parser {
 
 		$this->resolveChildUrls($p);
 		
-		if ($p->tagName == 'img' and $p->getAttribute('alt') !== '') {
+		if ($p->tagName == 'img' and $p->hasAttribute('alt')) {
 			$pValue = $p->getAttribute('alt');
-		} elseif ($p->tagName == 'area' and $p->getAttribute('alt') !== '') {
+		} elseif ($p->tagName == 'area' and $p->hasAttribute('alt')) {
 			$pValue = $p->getAttribute('alt');
-		} elseif ($p->tagName == 'abbr' and $p->getAttribute('title') !== '') {
+		} elseif ($p->tagName == 'abbr' and $p->hasAttribute('title')) {
 			$pValue = $p->getAttribute('title');
-		} elseif (in_array($p->tagName, array('data', 'input')) and $p->getAttribute('value') !== '') {
+		} elseif (in_array($p->tagName, array('data', 'input')) and $p->hasAttribute('value')) {
 			$pValue = $p->getAttribute('value');
 		} else {
 			$pValue = unicodeTrim($this->innerText($p));
@@ -611,11 +611,11 @@ class Parser {
 	 * @todo make this adhere to value-class
 	 */
 	public function parseU(\DOMElement $u) {
-		if (($u->tagName == 'a' or $u->tagName == 'area') and $u->getAttribute('href') !== null) {
+		if (($u->tagName == 'a' or $u->tagName == 'area') and $u->hasAttribute('href')) {
 			$uValue = $u->getAttribute('href');
-		} elseif (in_array($u->tagName, array('img', 'audio', 'video', 'source')) and $u->getAttribute('src') !== null) {
+		} elseif (in_array($u->tagName, array('img', 'audio', 'video', 'source')) and $u->hasAttribute('src')) {
 			$uValue = $u->getAttribute('src');
-		} elseif ($u->tagName == 'object' and $u->getAttribute('data') !== null) {
+		} elseif ($u->tagName == 'object' and $u->hasAttribute('data')) {
 			$uValue = $u->getAttribute('data');
 		}
 
@@ -627,9 +627,9 @@ class Parser {
 
 		if ($classTitle !== null) {
 			return $classTitle;
-		} elseif ($u->tagName == 'abbr' and $u->getAttribute('title') !== null) {
+		} elseif ($u->tagName == 'abbr' and $u->hasAttribute('title')) {
 			return $u->getAttribute('title');
-		} elseif (in_array($u->tagName, array('data', 'input')) and $u->getAttribute('value') !== null) {
+		} elseif (in_array($u->tagName, array('data', 'input')) and $u->hasAttribute('value')) {
 			return $u->getAttribute('value');
 		} else {
 			return unicodeTrim($this->textContent($u));
@@ -1132,7 +1132,7 @@ class Parser {
 
 					if ($el->tagName == 'img') {
 						return $el->getAttribute('src');
-					} else if ($el->tagName == 'object' && $el->getAttribute('data') != '') {
+					} else if ($el->tagName == 'object' && $el->hasAttribute('data')) {
 						return $el->getAttribute('data');
 					}
 

--- a/tests/Mf2/ParsePTest.php
+++ b/tests/Mf2/ParsePTest.php
@@ -70,6 +70,18 @@ class ParsePTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * @group parseP
 	 */
+	public function testParsePHandlesDataWithBlankValueAttribute() {
+		$input = '<div class="h-card"><data class="p-name" value="">Example User</data></div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayHasKey('name', $output['items'][0]['properties']);
+		$this->assertEquals('', $output['items'][0]['properties']['name'][0]);
+	}
+
+	/**
+	 * @group parseP
+	 */
 	public function testParsePReturnsEmptyStringForBrHr() {
 		$input = '<div class="h-card"><br class="p-name"/></div><div class="h-card"><hr class="p-name"/></div>';
 		$parser = new Parser($input);

--- a/tests/Mf2/ParseUTest.php
+++ b/tests/Mf2/ParseUTest.php
@@ -25,7 +25,31 @@ class ParseUTest extends PHPUnit_Framework_TestCase {
 		$this->assertArrayHasKey('url', $output['items'][0]['properties']);
 		$this->assertEquals('http://example.com', $output['items'][0]['properties']['url'][0]);
 	}
-	
+
+	/**
+	 * @group parseU
+	 */
+	public function testParseUHandlesEmptyHrefAttribute() {
+		$input = '<div class="h-card"><a class="u-url" href="">Awesome example website</a></div>';
+		$parser = new Parser($input, "http://example.com/");
+		$output = $parser->parse();
+		
+		$this->assertArrayHasKey('url', $output['items'][0]['properties']);
+		$this->assertEquals('http://example.com/', $output['items'][0]['properties']['url'][0]);
+	}
+
+	/**
+	 * @group parseU
+	 */
+	public function testParseUHandlesMissingHrefAttribute() {
+		$input = '<div class="h-card"><a class="u-url">Awesome example website</a></div>';
+		$parser = new Parser($input, "http://example.com/");
+		$output = $parser->parse();
+		
+		$this->assertArrayHasKey('url', $output['items'][0]['properties']);
+		$this->assertEquals('Awesome example website', $output['items'][0]['properties']['url'][0]);
+	}
+
 	/**
 	 * @group parseU
 	 */
@@ -72,6 +96,18 @@ class ParseUTest extends PHPUnit_Framework_TestCase {
 		
 		$this->assertArrayHasKey('photo', $output['items'][0]['properties']);
 		$this->assertEquals('http://example.com/someimage.png', $output['items'][0]['properties']['photo'][0]);
+	}
+
+	/**
+	 * @group parseU
+	 */
+	public function testParseUHandlesAbbrNoTitle() {
+		$input = '<div class="h-card"><abbr class="u-photo">no title attribute</abbr></div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+		
+		$this->assertArrayHasKey('photo', $output['items'][0]['properties']);
+		$this->assertEquals('no title attribute', $output['items'][0]['properties']['photo'][0]);
 	}
 	
 	/**
@@ -161,6 +197,17 @@ class ParseUTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('http://example.com/video.mp4', $output['items'][0]['properties']['video'][0]);
 	}
 
+	/**
+	 * @group parseU
+	 */
+	public function testParseUHandlesVideoNoSrc() {
+		$input = '<div class="h-entry"><video class="u-video">no video support</video></div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayHasKey('video', $output['items'][0]['properties']);
+		$this->assertEquals('no video support', $output['items'][0]['properties']['video'][0]);
+	}
 
 	/**
 	 * @group parseU
@@ -173,6 +220,19 @@ class ParseUTest extends PHPUnit_Framework_TestCase {
 		$this->assertArrayHasKey('video', $output['items'][0]['properties']);
 		$this->assertEquals('http://example.com/video.mp4', $output['items'][0]['properties']['video'][0]);
 		$this->assertEquals('http://example.com/video.ogg', $output['items'][0]['properties']['video'][1]);
+	}
+
+	/**
+	 * @group parseU
+	 */
+	public function testParseUHandlesVideoPoster() {
+		$input = '<div class="h-entry"><video class="u-photo" poster="http://example.com/posterimage.jpg"><source class="u-video" src="http://example.com/video.mp4" type="video/mp4"></video></div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayHasKey('video', $output['items'][0]['properties']);
+		$this->assertEquals('http://example.com/video.mp4', $output['items'][0]['properties']['video'][0]);
+		$this->assertEquals('http://example.com/posterimage.jpg', $output['items'][0]['properties']['photo'][0]);
 	}
 
 	/**

--- a/tests/Mf2/ParseUTest.php
+++ b/tests/Mf2/ParseUTest.php
@@ -225,19 +225,6 @@ class ParseUTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * @group parseU
 	 */
-	public function testParseUHandlesVideoPoster() {
-		$input = '<div class="h-entry"><video class="u-photo" poster="http://example.com/posterimage.jpg"><source class="u-video" src="http://example.com/video.mp4" type="video/mp4"></video></div>';
-		$parser = new Parser($input);
-		$output = $parser->parse();
-
-		$this->assertArrayHasKey('video', $output['items'][0]['properties']);
-		$this->assertEquals('http://example.com/video.mp4', $output['items'][0]['properties']['video'][0]);
-		$this->assertEquals('http://example.com/posterimage.jpg', $output['items'][0]['properties']['photo'][0]);
-	}
-
-	/**
-	 * @group parseU
-	 */
 	public function testParseUWithSpaces() {
 		$input = '<div class="h-card"><a class="u-url" href=" http://example.com ">Awesome example website</a></div>';
 		$parser = new Parser($input);


### PR DESCRIPTION
there were no tests for missing attributes, so this adds a few, and fixes the parse to test for the presence of attributes rather than the incorrect check `getAttribute('href') !== null` (getAttribute never returns null)