### PR TITLE
parse poster attribute for video tags

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -615,6 +615,8 @@ class Parser {
 			$uValue = $u->getAttribute('href');
 		} elseif (in_array($u->tagName, array('img', 'audio', 'video', 'source')) and $u->getAttribute('src') !== null) {
 			$uValue = $u->getAttribute('src');
+		} elseif ($u->tagName == 'video' and !$u->hasAttribute('src') and $u->hasAttribute('poster')) {
+			$uValue = $u->getAttribute('poster');
 		} elseif ($u->tagName == 'object' and $u->getAttribute('data') !== null) {
 			$uValue = $u->getAttribute('data');
 		}

--- a/tests/Mf2/ParseUTest.php
+++ b/tests/Mf2/ParseUTest.php
@@ -178,6 +178,19 @@ class ParseUTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * @group parseU
 	 */
+	public function testParseUHandlesVideoPoster() {
+		$input = '<div class="h-entry"><video class="u-photo" poster="http://example.com/posterimage.jpg"><source class="u-video" src="http://example.com/video.mp4" type="video/mp4"></video></div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertArrayHasKey('video', $output['items'][0]['properties']);
+		$this->assertEquals('http://example.com/video.mp4', $output['items'][0]['properties']['video'][0]);
+		$this->assertEquals('http://example.com/posterimage.jpg', $output['items'][0]['properties']['photo'][0]);
+	}
+
+	/**
+	 * @group parseU
+	 */
 	public function testParseUWithSpaces() {
 		$input = '<div class="h-card"><a class="u-url" href=" http://example.com ">Awesome example website</a></div>';
 		$parser = new Parser($input);


### PR DESCRIPTION
if there is a poster attribute and no src attribute on a video tag, the poster attribute is used as the value instead.

This test won't pass until after #119 is merged to fix the other `getAttribute` issues.

Closes #114 