### PR TITLE
Fixed language detection to support parsing of HTML fragments

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -508,7 +508,7 @@ class Parser {
 					return unicodeTrim($node->getAttribute('content'));
 				}
 			}
-		} else {
+		} elseif ($el->parentNode instanceof DOMElement) {
 			// check the parent node
 			return $this->language($el->parentNode);			
 		}

--- a/tests/Mf2/ParseLanguageTest.php
+++ b/tests/Mf2/ParseLanguageTest.php
@@ -52,6 +52,18 @@ class ParseLanguageTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('es', $result['items'][0]['properties']['html-lang']);
 	} # end method testHtmlAndHEntryLang()
 
+    /**
+     * Test HTML fragment with only h-entry lang
+     */
+    public function testFragmentHEntryLangOnly()
+    {
+        $input = '<div class="h-entry" lang="en">This test is in English.</div>';
+        $parser = new Parser($input);
+        $result = $parser->parse();
+
+        $this->assertEquals('en', $result['items'][0]['properties']['html-lang']);
+    } # end method testFragmentHEntryLangOnly()
+
 	/**
 	 * Test with different <html lang>, h-entry lang, and h-entry without lang,
 	 * which should inherit from the <html lang>

--- a/tests/Mf2/ParseLanguageTest.php
+++ b/tests/Mf2/ParseLanguageTest.php
@@ -64,6 +64,31 @@ class ParseLanguageTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('en', $result['items'][0]['properties']['html-lang']);
     } # end method testFragmentHEntryLangOnly()
 
+    /**
+     * Test HTML fragment with no lang
+     */
+    public function testFragmentHEntryNoLang()
+    {
+        $input = '<div class="h-entry">This test is in English.</div>';
+        $parser = new Parser($input);
+        $result = $parser->parse();
+
+        $this->assertFalse(isset($result['items'][0]['properties']['html-lang']));
+    } # end method testFragmentHEntryNoLang()
+
+    /**
+     * Test HTML fragment with no lang, loaded with loadXML()
+     */
+    public function testFragmentHEntryNoLangXML()
+    {
+        $input = new \DOMDocument();
+        $input->loadXML('<div class="h-entry">This test is in English.</div>');
+        $parser = new Parser($input);
+        $result = $parser->parse();
+
+        $this->assertFalse(isset($result['items'][0]['properties']['html-lang']));
+    } # end method testFragmentHEntryNoLangXML()
+
 	/**
 	 * Test with different <html lang>, h-entry lang, and h-entry without lang,
 	 * which should inherit from the <html lang>


### PR DESCRIPTION
The current way of language detection breaks when parsing an HTML fragment only (instead of a complete HTML document). The parser expects an `<html>` element to be present and will run into

```
Argument 1 passed to Mf2\Parser::language() must be an instance of DOMElement, instance of DOMDocument given, called in L:\micrometa\vendor\mf2\mf2\Mf2\Parser.php on line 513 and defined
```

otherwise. Making sure the parent node is a `DOMElement` before recursing fixes the problem.