### PR TITLE
Add rel-urls object

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -280,6 +280,9 @@ class Parser {
 	/** @var boolean Whether to include experimental language parsing in the result */
 	public $lang = false;
 
+	/** @var bool Whether to include alternates object (dropped from spec in favor of rel-urls) */
+	public $enableAlternates = false;
+
 	/**
 	 * Elements upgraded to mf2 during backcompat
 	 * @var SplObjectStorage
@@ -1153,21 +1156,25 @@ class Parser {
 	}
 
 	/**
-	 * Parse Rels and Alternatives
+	 * Parse rels and alternates
 	 *
-	 * Returns [$rels, $alternatives]. If the $rels value is to be empty, i.e. there are no links on the page
-	 * with a rel value *not* containing `alternate`, then the type of $rels depends on $this->jsonMode. If set
-	 * to true, it will be a stdClass instance, optimising for JSON serialisation. Otherwise (the default case),
-	 * it will be an empty array.
+	 * Returns [$rels, $rel_urls, $alternates].
+	 * For $rels and $rel_urls, if they are empty and $this->jsonMode = true, they will be returned as stdClass,
+	 * optimizing for JSON serialization. Otherwise they will be returned as an empty array.
+	 * Note that $alternates is deprecated in the microformats spec in favor of $rel_urls. $alternates only appears
+	 * in parsed results if $this->enableAlternates = true.
+	 * @return array|stdClass
 	 */
 	public function parseRelsAndAlternates() {
 		$rels = array();
+		$rel_urls = array();
 		$alternates = array();
 
 		// Iterate through all a, area and link elements with rel attributes
 		foreach ($this->xpath->query('//a[@rel and @href] | //link[@rel and @href] | //area[@rel and @href]') as $hyperlink) {
-			if ($hyperlink->getAttribute('rel') == '')
+			if ($hyperlink->getAttribute('rel') == '') {
 				continue;
+			}
 
 			// Resolve the href
 			$href = $this->resolveUrl($hyperlink->getAttribute('href'));
@@ -1175,40 +1182,63 @@ class Parser {
 			// Split up the rel into space-separated values
 			$linkRels = array_filter(explode(' ', $hyperlink->getAttribute('rel')));
 
-			// If alternate in rels, create alternate structure, append
-			if (in_array('alternate', $linkRels)) {
-				$alt = array(
-					'url' => $href,
-					'rel' => implode(' ', array_diff($linkRels, array('alternate')))
-				);
-				if ($hyperlink->hasAttribute('media'))
-					$alt['media'] = $hyperlink->getAttribute('media');
+			$rel_attributes = array();
 
-				if ($hyperlink->hasAttribute('hreflang'))
-					$alt['hreflang'] = $hyperlink->getAttribute('hreflang');
+			if ($hyperlink->hasAttribute('media')) {
+				$rel_attributes['media'] = $hyperlink->getAttribute('media');
+			}
 
-				if ($hyperlink->hasAttribute('title'))
-					$alt['title'] = $hyperlink->getAttribute('title');
+			if ($hyperlink->hasAttribute('hreflang')) {
+				$rel_attributes['hreflang'] = $hyperlink->getAttribute('hreflang');
+			}
 
-				if ($hyperlink->hasAttribute('type'))
-					$alt['type'] = $hyperlink->getAttribute('type');
+			if ($hyperlink->hasAttribute('title')) {
+				$rel_attributes['title'] = $hyperlink->getAttribute('title');
+			}
 
-				if ($hyperlink->nodeValue)
-					$alt['text'] = $hyperlink->nodeValue;
+			if ($hyperlink->hasAttribute('type')) {
+				$rel_attributes['type'] = $hyperlink->getAttribute('type');
+			}
 
-				$alternates[] = $alt;
-			} else {
-				foreach ($linkRels as $rel) {
-					$rels[$rel][] = $href;
+			if ($hyperlink->nodeValue) {
+				$rel_attributes['text'] = $hyperlink->nodeValue;
+			}
+
+			if ($this->enableAlternates) {
+				// If 'alternate' in rels, create 'alternates' structure, append
+				if (in_array('alternate', $linkRels)) {
+					$alternates[] = array_merge(
+						$rel_attributes,
+						array(
+							'url' => $href,
+							'rel' => implode(' ', array_diff($linkRels, array('alternate')))
+						)
+					);
 				}
 			}
+
+			foreach ($linkRels as $rel) {
+				$rels[$rel][] = $href;
+			}
+
+			if (!in_array($href, $rel_urls)) {
+				$rel_urls[$href] = array_merge(
+					$rel_attributes, 
+					array('rels' => $linkRels)
+				);
+			}
+
 		}
 
 		if (empty($rels) and $this->jsonMode) {
 			$rels = new stdClass();
 		}
 
-		return array($rels, $alternates);
+		if (empty($rel_urls) and $this->jsonMode) {
+			$rel_urls = new stdClass();
+		}		
+		
+		return array($rels, $rel_urls, $alternates);
 	}
 
 	/**
@@ -1239,14 +1269,15 @@ class Parser {
 		}
 
 		// Parse rels
-		list($rels, $alternates) = $this->parseRelsAndAlternates();
+		list($rels, $rel_urls, $alternates) = $this->parseRelsAndAlternates();
 
 		$top = array(
 			'items' => array_values(array_filter($mfs)),
-			'rels' => $rels
+			'rels' => $rels,
+			'rel-urls' => $rel_urls,
 		);
 
-		if (count($alternates)) {
+		if ($this->enableAlternates && count($alternates)) {
 			$top['alternates'] = $alternates;
 		}
 

--- a/tests/Mf2/ClassicMicroformatsTest.php
+++ b/tests/Mf2/ClassicMicroformatsTest.php
@@ -24,14 +24,14 @@ class ClassicMicroformatsTest extends PHPUnit_Framework_TestCase {
 	
 	public function testParsesClassicHcard() {
 		$input = '<div class="vcard"><span class="fn n">Barnaby Walters</span> is a person.</div>';
-		$expected = '{"items": [{"type": ["h-card"], "properties": {"name": ["Barnaby Walters"]}}], "rels": {}}';
+		$expected = '{"items": [{"type": ["h-card"], "properties": {"name": ["Barnaby Walters"]}}], "rels": {}, "rel-urls": {}}';
 		$parser = new Parser($input, '', true);
 		$this->assertJsonStringEqualsJsonString(json_encode($parser->parse()), $expected);
 	}
 	
 	public function testParsesClassicHEntry() {
 		$input = '<div class="hentry"><h1 class="entry-title">microformats2 Is Great</h1> <p class="entry-summary">yes yes it is.</p></div>';
-		$expected = '{"items": [{"type": ["h-entry"], "properties": {"name": ["microformats2 Is Great"], "summary": ["yes yes it is."]}}], "rels": {}}';
+		$expected = '{"items": [{"type": ["h-entry"], "properties": {"name": ["microformats2 Is Great"], "summary": ["yes yes it is."]}}], "rels": {}, "rel-urls": {}}';
 		$parser = new Parser($input, '', true);
 		$this->assertJsonStringEqualsJsonString(json_encode($parser->parse()), $expected);
 	}

--- a/tests/Mf2/CombinedMicroformatsTest.php
+++ b/tests/Mf2/CombinedMicroformatsTest.php
@@ -37,6 +37,7 @@ class CombinedMicroformatsTest extends PHPUnit_Framework_TestCase {
 </div>';
 		$expected = '{
 	"rels": {},
+	"rel-urls": {},
 	"items": [{ 
 		"type": ["h-event"],
 		"properties": {
@@ -79,6 +80,7 @@ class CombinedMicroformatsTest extends PHPUnit_Framework_TestCase {
 </div>';
 		$expected = '{
 	"rels": {},
+	"rel-urls": {},
   "items": [{ 
 	"type": ["h-card"],
 	"properties": {
@@ -110,6 +112,7 @@ class CombinedMicroformatsTest extends PHPUnit_Framework_TestCase {
 </div>';
 		$expected = '{
 	"rels": {},
+	"rel-urls": {},
   "items": [{ 
 	"type": ["h-card"],
 	"properties": {
@@ -148,6 +151,7 @@ class CombinedMicroformatsTest extends PHPUnit_Framework_TestCase {
 </div>';
 		$expected = '{
 	"rels": {},
+	"rel-urls": {},
   "items": [{ 
 	"type": ["h-card"],
 	"properties": {
@@ -184,6 +188,7 @@ class CombinedMicroformatsTest extends PHPUnit_Framework_TestCase {
 </div>';
 		$expected = '{
 	"rels": {},
+	"rel-urls": {},
   "items": [{ 
 		"type": ["h-card"],
 		"properties": {
@@ -286,7 +291,8 @@ class CombinedMicroformatsTest extends PHPUnit_Framework_TestCase {
           }]
 	      }
 	    }],
-	    "rels":[]
+	    "rels":[],
+	    "rel-urls": []
 	  }';
 	  	$mf = Mf2\parse($input);
 

--- a/tests/Mf2/MicroformatsWikiExamplesTest.php
+++ b/tests/Mf2/MicroformatsWikiExamplesTest.php
@@ -29,6 +29,7 @@ class MicroformatsWikiExamplesTest extends PHPUnit_Framework_TestCase {
 		$input = '';
 		$expected = '{
 	"rels": {},
+	"rel-urls": {},
 	"items": []
 }';
 		
@@ -42,6 +43,7 @@ class MicroformatsWikiExamplesTest extends PHPUnit_Framework_TestCase {
 		$input = Null;
 		$expected = '{
 	"rels": {},
+	"rel-urls": {},
 	"items": []
 }';
 		
@@ -59,6 +61,7 @@ class MicroformatsWikiExamplesTest extends PHPUnit_Framework_TestCase {
 		$input = '<span class="h-card">Frances Berriman</span>';
 		$expected = '{
 	"rels": {},
+	"rel-urls": {},
   "items": [{ 
 	"type": ["h-card"],
 	"properties": {
@@ -79,6 +82,7 @@ class MicroformatsWikiExamplesTest extends PHPUnit_Framework_TestCase {
 		$input = '<a class="h-card" href="http://benward.me">Ben Ward</a>';
 		$expected = '{
 	"rels": {},
+	"rel-urls": {},
   "items": [{ 
 	"type": ["h-card"],
 	"properties": {
@@ -101,6 +105,7 @@ class MicroformatsWikiExamplesTest extends PHPUnit_Framework_TestCase {
 		// Added root items key
 		$expected = '{
 	"rels": {},
+	"rel-urls": {},
 	"items": [{ 
   "type": ["h-card"],
   "properties": {
@@ -125,6 +130,7 @@ class MicroformatsWikiExamplesTest extends PHPUnit_Framework_TestCase {
 		// Added root items key
 		$expected = '{
 	"rels": {},
+	"rel-urls": {},
 	"items": [{ 
   "type": ["h-card"],
   "properties": {
@@ -162,6 +168,7 @@ class MicroformatsWikiExamplesTest extends PHPUnit_Framework_TestCase {
 
 		$expected = '{
   "rels": {},
+  "rel-urls": {},
 	"items": [{ 
 	"type": ["h-card"],
 	"properties": {

--- a/tests/Mf2/ParseImpliedTest.php
+++ b/tests/Mf2/ParseImpliedTest.php
@@ -132,6 +132,7 @@ class ParseImpliedTest extends PHPUnit_Framework_TestCase {
 </a>';
 		$expected = '{
 	"rels": {},
+	"rel-urls": {},
 	"items": [{
 		"type": ["h-card"],
 		"properties": {

--- a/tests/Mf2/ParserTest.php
+++ b/tests/Mf2/ParserTest.php
@@ -164,6 +164,7 @@ class ParserTest extends PHPUnit_Framework_TestCase {
 	public function testParsesRelAlternateValues() {
 		$input = '<a rel="alternate home" href="http://example.org" hreflang="de", media="screen" type="text/html" title="German Homepage Link">German Homepage</a>';
 		$parser = new Parser($input);
+		$parser->enableAlternates = true;
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('alternates', $output);

--- a/tests/Mf2/RelTest.php
+++ b/tests/Mf2/RelTest.php
@@ -94,4 +94,86 @@ class RelTest extends PHPUnit_Framework_TestCase {
     $this->assertArrayNotHasKey('webmention', $output['rels']);
   }
 
+  public function testEnableAlternatesFlagTrue() {
+    $input = '<a rel="author" href="http://example.com/a">author a</a>
+<a rel="author" href="http://example.com/b">author b</a>
+<a rel="in-reply-to" href="http://example.com/1">post 1</a>
+<a rel="in-reply-to" href="http://example.com/2">post 2</a>
+<a rel="alternate home"
+   href="http://example.com/fr"
+   media="handheld"
+   hreflang="fr">French mobile homepage</a>';
+    $parser = new Parser($input);
+    $parser->enableAlternates = true;
+    $output = $parser->parse();
+
+    $this->assertArrayHasKey('alternates', $output);
+  }
+
+  public function testEnableAlternatesFlagFalse() {
+    $input = '<a rel="author" href="http://example.com/a">author a</a>
+<a rel="author" href="http://example.com/b">author b</a>
+<a rel="in-reply-to" href="http://example.com/1">post 1</a>
+<a rel="in-reply-to" href="http://example.com/2">post 2</a>
+<a rel="alternate home"
+   href="http://example.com/fr"
+   media="handheld"
+   hreflang="fr">French mobile homepage</a>';
+    $parser = new Parser($input);
+    $parser->enableAlternates = false;
+    $output = $parser->parse();
+
+    $this->assertArrayNotHasKey('alternates', $output);
+  }
+
+  /**
+   * @see https://github.com/indieweb/php-mf2/issues/112
+   * @see http://microformats.org/wiki/microformats2-parsing#rel_parse_examples
+   */
+  public function testRelURLs() {
+    $input = '<a rel="author" href="http://example.com/a">author a</a>
+<a rel="author" href="http://example.com/b">author b</a>
+<a rel="in-reply-to" href="http://example.com/1">post 1</a>
+<a rel="in-reply-to" href="http://example.com/2">post 2</a>
+<a rel="alternate home"
+   href="http://example.com/fr"
+   media="handheld"
+   hreflang="fr">French mobile homepage</a>
+<link rel="alternate" type="application/atom+xml" href="http://example.com/articles.atom" title="Atom Feed" />';
+    $parser = new Parser($input);
+    $output = $parser->parse();
+
+    $this->assertArrayHasKey('rels', $output);
+    $this->assertCount(4, $output['rels']);
+    $this->assertArrayHasKey('author', $output['rels']);
+    $this->assertArrayHasKey('in-reply-to', $output['rels']);
+    $this->assertArrayHasKey('alternate', $output['rels']);
+    $this->assertArrayHasKey('home', $output['rels']);
+
+    $this->assertArrayHasKey('rel-urls', $output);
+    $this->assertCount(6, $output['rel-urls']);
+    $this->assertArrayHasKey('http://example.com/a', $output['rel-urls']);
+    $this->assertArrayHasKey('http://example.com/b', $output['rel-urls']);
+    $this->assertArrayHasKey('http://example.com/1', $output['rel-urls']);
+    $this->assertArrayHasKey('http://example.com/2', $output['rel-urls']);
+    $this->assertArrayHasKey('http://example.com/fr', $output['rel-urls']);
+    $this->assertArrayHasKey('http://example.com/articles.atom', $output['rel-urls']);
+
+    $this->assertArrayHasKey('rels', $output['rel-urls']['http://example.com/a']);
+    $this->assertArrayHasKey('text', $output['rel-urls']['http://example.com/a']);
+    $this->assertArrayHasKey('rels', $output['rel-urls']['http://example.com/b']);
+    $this->assertArrayHasKey('text', $output['rel-urls']['http://example.com/b']);
+    $this->assertArrayHasKey('rels', $output['rel-urls']['http://example.com/1']);
+    $this->assertArrayHasKey('text', $output['rel-urls']['http://example.com/1']);
+    $this->assertArrayHasKey('rels', $output['rel-urls']['http://example.com/2']);
+    $this->assertArrayHasKey('text', $output['rel-urls']['http://example.com/2']);
+    $this->assertArrayHasKey('rels', $output['rel-urls']['http://example.com/fr']);
+    $this->assertArrayHasKey('text', $output['rel-urls']['http://example.com/fr']);
+    $this->assertArrayHasKey('media', $output['rel-urls']['http://example.com/fr']);
+    $this->assertArrayHasKey('hreflang', $output['rel-urls']['http://example.com/fr']);
+    $this->assertArrayHasKey('title', $output['rel-urls']['http://example.com/articles.atom']);
+    $this->assertArrayHasKey('type', $output['rel-urls']['http://example.com/articles.atom']);
+    $this->assertArrayHasKey('rels', $output['rel-urls']['http://example.com/articles.atom']);
+  }
+
 }


### PR DESCRIPTION
- Add test for rel-urls
- Remove 'alternates' in favor of 'rel-urls' per spec; still available with flag $enableAlternates = true
- Add tests for $enableAlterates flag
- Update existing tests to include expected empty rel-urls object

Fixes #112 