### PR TITLE
Add test and fix for #149

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -244,13 +244,13 @@ function convertTimeFormat($time) {
  * @return string isolated, normalized TZ offset for implied TZ for other dt- properties
  */
 function normalizeTimezoneOffset(&$dtValue) {
-	preg_match('/Z|[+-]\d{1,2}:?(\d{2})?$/i', $dtValue, $matches);	
+	preg_match('/Z|[+-]\d{1,2}:?(\d{2})?$/i', $dtValue, $matches);
 
 	if (empty($matches)) {
 		return null;
 	}
 
-  $timezoneOffset = null;
+	$timezoneOffset = null;
 
 	if ( $matches[0] != 'Z' ) {
 		$timezoneString = str_replace(':', '', $matches[0]);

--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -845,11 +845,12 @@ class Parser {
 				$dtValue = $this->textContent($dt);
 			}
 
-			// if the dtValue is not just YYYY-MM-DD, normalize the timezone offset
+			// if the dtValue is not just YYYY-MM-DD
 			if (!preg_match('/^(\d{4}-\d{2}-\d{2})$/', $dtValue)) {
-				$timezoneOffset = normalizeTimezoneOffset($dtValue);
-				if (!$impliedTimezone && $timezoneOffset) {
-					$impliedTimezone = $timezoneOffset;
+				// no implied timezone set and dtValue has a TZ offset, use un-normalized TZ offset
+				preg_match('/Z|[+-]\d{1,2}:?(\d{2})?$/i', $dtValue, $matches);
+				if (!$impliedTimezone && !empty($matches[0])) {
+					$impliedTimezone = $matches[0];
 				}
 			}
 
@@ -1031,7 +1032,7 @@ class Parser {
 		foreach ($temp_dates as $propName => $data) {
 			foreach ( $data as $dtValue ) {
 				// var_dump(preg_match('/[+-]\d{2}(\d{2})?$/i', $dtValue));
-				if ( $impliedTimezone && preg_match('/[+-]\d{2}(\d{2})?$/i', $dtValue, $matches) == 0 ) {
+				if ( $impliedTimezone && preg_match('/[+-]\d{2}:?(\d{2})?$/i', $dtValue, $matches) == 0 ) {
 					$dtValue .= $impliedTimezone;
 				}
 

--- a/tests/Mf2/ParseDTTest.php
+++ b/tests/Mf2/ParseDTTest.php
@@ -260,9 +260,11 @@ class ParseDTTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * 
+	 * TZ offsets normalized only for VCP.
+	 * This behavior is implied from "However the colons ":" separating the hours and minutes of any timezone offset are optional and discouraged in order to make it less likely that a timezone offset will be confused for a time."
+	 * @see http://microformats.org/wiki/index.php?title=value-class-pattern&oldid=66473##However+the+colons
 	 */
-	public function testNormalizeTZOffset() {
+	public function testNormalizeTZOffsetVCP() {
 		$input = '<div class="h-event">
             <span class="dt-start"> <time class="value" datetime="2017-05-27">May 27</time>, from
             <time class="value">20:57-07:00</time> </span>
@@ -272,6 +274,19 @@ class ParseDTTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals('2017-05-27 20:57-0700', $output['items'][0]['properties']['start'][0]);
 	}
+
+
+	/**
+	 * TZ offsets *not* normalized for non-VCP dates
+	 */
+	public function testNoNormalizeTZOffset() {
+		$input = '<div class="h-entry"> <time class="dt-start" datetime="2018-03-13 15:30-07:00">March 13, 2018 3:30PM</time> </div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertEquals('2018-03-13 15:30-07:00', $output['items'][0]['properties']['start'][0]);
+	}
+
 
 	/**
 	 * @see https://github.com/indieweb/php-mf2/issues/115
@@ -297,7 +312,7 @@ class ParseDTTest extends PHPUnit_Framework_TestCase {
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
-		$this->assertEquals('2009-06-26T19:01-0800', $output['items'][0]['properties']['start'][0]);
+		$this->assertEquals('2009-06-26T19:01-08:00', $output['items'][0]['properties']['start'][0]);
 	}
 
 	/**

--- a/tests/Mf2/ParseDTTest.php
+++ b/tests/Mf2/ParseDTTest.php
@@ -469,5 +469,16 @@ class ParseDTTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('2014-06-01 19:30-0600', $output['items'][0]['properties']['end'][0]);
 	}
 
+	/**
+	 * @see https://github.com/indieweb/php-mf2/issues/149
+	 */
+	public function testDtWithoutYear() {
+		$input = '<div class="h-card"> <time class="dt-bday" datetime="--12-28"></time> </div>';
+		$parser = new Parser($input);
+		$output = $parser->parse();
+
+		$this->assertEquals('--12-28', $output['items'][0]['properties']['bday'][0]);
+	}
+
 }
 


### PR DESCRIPTION
Also update tests for normalized timezones in VCP dates.
No longer normalizes timezone for non-VCP dates.
Additional test and comments.
Fixes #149 