### PR TITLE
Improve rel parsing

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -1277,8 +1277,8 @@ class Parser {
 				$rel_attributes['type'] = $hyperlink->getAttribute('type');
 			}
 
-			if ($hyperlink->nodeValue) {
-				$rel_attributes['text'] = $hyperlink->nodeValue;
+			if (strlen($hyperlink->textContent) > 0) {
+				$rel_attributes['text'] = $hyperlink->textContent;
 			}
 
 			if ($this->enableAlternates) {

--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -1295,7 +1295,11 @@ class Parser {
 			}
 
 			foreach ($linkRels as $rel) {
-				$rels[$rel][] = $href;
+				if (!array_key_exists($rel, $rels)) {
+					$rels[$rel] = array($href);
+				} elseif (!in_array($href, $rels[$rel])) {
+					$rels[$rel][] = $href;
+				}
 			}
 
 			if (!array_key_exists($href, $rel_urls)) {

--- a/tests/Mf2/RelTest.php
+++ b/tests/Mf2/RelTest.php
@@ -209,4 +209,14 @@ class RelTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($output['rels']['a'], array('#a', '#b'));
   }
 
+  public function testRelURLsFalsyTextVSEmpty() {
+    $input = '<a href="#a" rel="a">0</a>
+<a href="#b" rel="b"></a>';
+    $parser = new Parser($input);
+    $output = $parser->parse();
+    $this->assertArrayHasKey('text', $output['rel-urls']['#a']);
+    $this->assertEquals($output['rel-urls']['#a']['text'], '0');
+    $this->assertArrayNotHasKey('text', $output['rel-urls']['#b']);
+  }
+
 }

--- a/tests/Mf2/RelTest.php
+++ b/tests/Mf2/RelTest.php
@@ -188,4 +188,16 @@ class RelTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($output['rel-urls']['#']['rels'], ['archived', 'bookmark', 'me']);
   }
 
+  public function testRelURLsInfoMergesCorrectly() {
+    $input = '<a href="#" rel="a">This nodeValue</a>
+<a href="#" rel="a" hreflang="en">Not this nodeValue</a>';
+    $parser = new Parser($input);
+    $output = $parser->parse();
+    $this->assertEquals($output['rel-urls']['#']['hreflang'], 'en');
+    $this->assertArrayNotHasKey('media', $output['rel-urls']['#']);
+    $this->assertArrayNotHasKey('title', $output['rel-urls']['#']);
+    $this->assertArrayNotHasKey('type', $output['rel-urls']['#']);
+    $this->assertEquals($output['rel-urls']['#']['text'], 'This nodeValue');
+  }
+
 }

--- a/tests/Mf2/RelTest.php
+++ b/tests/Mf2/RelTest.php
@@ -176,4 +176,16 @@ class RelTest extends PHPUnit_Framework_TestCase {
     $this->assertArrayHasKey('rels', $output['rel-urls']['http://example.com/articles.atom']);
   }
 
+  /**
+   * @see https://github.com/microformats/microformats2-parsing/issues/29
+   * @see https://github.com/microformats/microformats2-parsing/issues/30
+   */
+  public function testRelURLsRelsUniqueAndSorted() {
+    $input = '<a href="#" rel="me bookmark"></a>
+<a href="#" rel="bookmark archived"></a>';
+    $parser = new Parser($input);
+    $output = $parser->parse();
+    $this->assertEquals($output['rel-urls']['#']['rels'], ['archived', 'bookmark', 'me']);
+  }
+
 }

--- a/tests/Mf2/RelTest.php
+++ b/tests/Mf2/RelTest.php
@@ -185,7 +185,7 @@ class RelTest extends PHPUnit_Framework_TestCase {
 <a href="#" rel="bookmark archived"></a>';
     $parser = new Parser($input);
     $output = $parser->parse();
-    $this->assertEquals($output['rel-urls']['#']['rels'], ['archived', 'bookmark', 'me']);
+    $this->assertEquals($output['rel-urls']['#']['rels'], array('archived', 'bookmark', 'me'));
   }
 
   public function testRelURLsInfoMergesCorrectly() {
@@ -206,7 +206,7 @@ class RelTest extends PHPUnit_Framework_TestCase {
 <a href="#a" rel="a"></a>';
     $parser = new Parser($input);
     $output = $parser->parse();
-    $this->assertEquals($output['rels']['a'], ['#a', '#b']);
+    $this->assertEquals($output['rels']['a'], array('#a', '#b'));
   }
 
 }

--- a/tests/Mf2/RelTest.php
+++ b/tests/Mf2/RelTest.php
@@ -200,4 +200,13 @@ class RelTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($output['rel-urls']['#']['text'], 'This nodeValue');
   }
 
+  public function testRelURLsNoDuplicates() {
+    $input = '<a href="#a" rel="a"></a>
+<a href="#b" rel="a"></a>
+<a href="#a" rel="a"></a>';
+    $parser = new Parser($input);
+    $output = $parser->parse();
+    $this->assertEquals($output['rels']['a'], ['#a', '#b']);
+  }
+
 }


### PR DESCRIPTION
* Parsing of the `rel` attribute has been improved by using WHATWG’s definition of [splitting on whitespace](https://infra.spec.whatwg.org/#split-on-ascii-whitespace). We also treat it as [a set](https://infra.spec.whatwg.org/#sets), which means we drop duplicate values. This might spare us a loop or two.
  
* The properties (`hreflang`, `media`, `title`, `type`, `text`) we add to the `rel-urls` object should only be added if they weren’t previously set. Overwriting order has been changed to accord with this.
  
  The test `testRelURLsInfoMergesCorrectly` is a simple check for the correct behaviour.
  
* The final `rels` array within the `rel-urls` object has been changed to contain only unique items, sorted alphabetically. This reflects [the latest parsing specification change](http://microformats.org/wiki/index.php?title=microformats2-parsing&diff=66724&oldid=66723).
  
  The test `testRelURLsRelsUniqueAndSorted` is a simple check for both uniqueness and order.
  
* The arrays of URLs within the `rels` object should not contain duplicates. The code has been changed to not add any URLs that are already present in the array. Based on the following line in the parsing spec, that had me reread it thrice as a non-native English speaker:
  
  > * if url is not in the array of the key rel-value in the rels hash then add url to the array
  
  The test `testRelURLsNoDuplicates` is a simple check to make sure duplicate URLs aren’t added.

Closes #159 if merged.