### PR TITLE
Stop adding whitespace in html that is not in the source document

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -897,10 +897,17 @@ class Parser {
 		// TODO: as it is this is not relative to only children, make this .// and rerun tests
 		$this->resolveChildUrls($e);
 
-		$html = '';
-		foreach ($e->childNodes as $node) {
-			$html .= $node->ownerDocument->saveHTML($node);
+		// Temporarily move all descendants into a separate DocumentFragment.
+		// This way we can DOMDocument::saveHTML on the entire collection at once.
+		// Running DOMDocument::saveHTML per node may add whitespace that isn't in source.
+		// See https://stackoverflow.com/q/38317903
+		$innerNodes = $e->ownerDocument->createDocumentFragment();
+		while ($e->hasChildNodes()) {
+			$innerNodes->appendChild($e->firstChild);
 		}
+		$html = $e->ownerDocument->saveHtml($innerNodes);
+		// Put the nodes back in place.
+		$e->appendChild($innerNodes);
 
 		$return = array(
 			'html' => unicodeTrim($html),

--- a/tests/Mf2/ParserTest.php
+++ b/tests/Mf2/ParserTest.php
@@ -696,5 +696,12 @@ END;
     $this->assertEquals('Comment D', $three['children'][1]['properties']['name'][0]);
     $this->assertEquals('Four', $output['items'][0]['children'][3]['properties']['name'][0]);
   }
+  
+  public function testNoErrantWhitespaceOnEHtml()
+  {
+    $input = '<div class="h-entry"><div class="e-content"><p>1</p><p>2</p></div></div>';
+    $output = Mf2\parse($input);
+    $this->assertEquals('<p>1</p><p>2</p>', $output['items'][0]['properties']['content'][0]['html']);
+  }
 }
 


### PR DESCRIPTION
This seems to be an under-documented feature of [`DOMDocument::saveHTML`](https://php.net/manual/en/domdocument.savehtml.php). It may sometimes add a `\n` at the end of its output. So when you just concatenate the string outputs of this method you may be introducing line breaks that weren’t in the original source.

I think adding a [`trim`](https://secure.php.net/manual/en/function.trim.php) of some sort is wrong, as you might then also be trimming Text nodes that actually should contain the line break.

Instead what I have found to fix this is to move all the nodes into a [`DocumentFragment`](https://secure.php.net/manual/en/class.domdocumentfragment.php) and retrieving the HTML of this fragment in one go.

---

Prior to this fix, [the parser returns the following](http://pin13.net/mf2/?id=20180325110741883), note the `\n` in `["properties"]["content"][0]["html"]`:

```html
<div class="h-entry"><div class="e-content"><p>1</p><p>2</p></div></div>
```
```json
{
  "type": [ "h-entry" ],
  "properties": {
    "content": [ {
      "html": "<p>1</p>\n<p>2</p>",
      "value": "1 2"
    } ]
  }
}
```