### PR TITLE
New algorithm for plain text values

### DIFF
--- a/tests/Mf2/ParseImpliedTest.php
+++ b/tests/Mf2/ParseImpliedTest.php
@@ -193,8 +193,8 @@ class ParseImpliedTest extends PHPUnit_Framework_TestCase {
 		$inner = "Name	\nand more";
 		$test = '<span class="h-card"> ' . $inner .' </span><span class="h-card"><span class="p-name"> ' . $inner . ' </span></span>';
 		$result = Mf2\parse($test);
-		$this->assertEquals($inner, $result['items'][0]['properties']['name'][0]);
-		$this->assertEquals($inner, $result['items'][1]['properties']['name'][0]);
+		$this->assertEquals('Name and more', $result['items'][0]['properties']['name'][0]);
+		$this->assertEquals('Name and more', $result['items'][1]['properties']['name'][0]);
 	}
 
 

--- a/tests/Mf2/ParserTest.php
+++ b/tests/Mf2/ParserTest.php
@@ -93,7 +93,7 @@ class ParserTest extends PHPUnit_Framework_TestCase {
 		$output = $parser->parse();
 
 		$this->assertEquals('Blah blah <a href="http://example.com/a-url">thing</a>. <object data="http://example.com/object"></object> <img src="http://example.com/img">', $output['items'][0]['properties']['content'][0]['html']);
-		$this->assertEquals('Blah blah thing.  http://example.com/img', $output['items'][0]['properties']['content'][0]['value']);
+		$this->assertEquals('Blah blah thing. http://example.com/img', $output['items'][0]['properties']['content'][0]['value']);
 	}
 
 	public function testParseEWithBR() {
@@ -156,7 +156,7 @@ class ParserTest extends PHPUnit_Framework_TestCase {
 
 
 	public function testHtmlEncodesImpliedProperties() {
-		$input = '<a class="h-card" href="&lt;url&gt;"><img src="&lt;img&gt;" />&lt;name&gt;</a>';
+		$input = '<a class="h-card" href="&lt;url&gt;"><img src="&lt;img&gt;" alt="" />&lt;name&gt;</a>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
 

--- a/tests/Mf2/PlainTextTest.php
+++ b/tests/Mf2/PlainTextTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Mf2\Parser\Test;
+
+class PlainTextTest extends \PHPUnit_Framework_TestCase {
+    /**
+     * @dataProvider aaronpkExpectations
+     */
+    public function testAaronpkExpectations($input, $pName, $eValue, $eHtml) {
+        $parser = new \Mf2\Parser($input);
+        $output = $parser->parse();
+        $entryProperties = $output['items'][0]['properties'];
+        $this->assertEquals($pName, $entryProperties['name'][0]);
+        $this->assertEquals($eValue, $entryProperties['content'][0]['value']);
+        $this->assertEquals($eHtml, $entryProperties['content'][0]['html']);
+    }
+
+    public function aaronpkExpectations() {
+        return array(
+            1 => array(
+                "<div class=\"h-entry\">\n  <div class=\"e-content p-name\"><p>Hello World</p></div>\n</div>",
+                "Hello World",
+                "Hello World",
+                "<p>Hello World</p>"
+            ),
+            2 => array(
+                "<div class=\"h-entry\">\n  <div class=\"e-content p-name\"><p>Hello<br>World</p></div>\n</div>",
+                "Hello\nWorld",
+                "Hello\nWorld",
+                "<p>Hello<br>World</p>"
+            ),
+            3 => array(
+                "<div class=\"h-entry\">\n  <div class=\"e-content p-name\"><p>Hello<br>\nWorld</p></div>\n</div>",
+                "Hello\nWorld",
+                "Hello\nWorld",
+                "<p>Hello<br>\nWorld</p>"
+            ),
+            4 => array(
+                "<div class=\"h-entry\">\n  <div class=\"e-content p-name\">\n    <p>Hello World</p>\n  </div>\n</div>",
+                "Hello World",
+                "Hello World",
+                "<p>Hello World</p>"
+            ),
+            5 => array(
+                "<div class=\"h-entry\">\n  <div class=\"e-content p-name\">Hello\nWorld</div>\n</div>",
+                "Hello World",
+                "Hello World",
+                "Hello\nWorld"
+            ),
+            6 => array(
+                "<div class=\"h-entry\">\n  <div class=\"e-content p-name\"><p>Hello</p><p>World</p></div>\n</div>",
+                "Hello\nWorld",
+                "Hello\nWorld",
+                "<p>Hello</p><p>World</p>"
+            ),
+            7 => array(
+                "<div class=\"h-entry\">\n  <div class=\"e-content p-name\">Hello<br>\n    World</div>\n</div>",
+                "Hello\nWorld",
+                "Hello\nWorld",
+                "Hello<br>\n    World",
+            ),
+            8 => array(
+                "<div class=\"h-entry\">\n  <div class=\"e-content p-name\"><br>Hello<br>World<br></div>\n</div>",
+                "Hello\nWorld",
+                "Hello\nWorld",
+                "<br>Hello<br>World<br>"
+            ),
+            9 => array(
+                "<div class=\"h-entry\">\n  <div class=\"e-content p-name\">\n    <p>One</p>\n    <p>Two</p>\n    <p>Three</p>\n  </div>\n</div>",
+                "One\nTwo\nThree",
+                "One\nTwo\nThree",
+                "<p>One</p>\n    <p>Two</p>\n    <p>Three</p>"
+            )
+        );
+    }
+}


### PR DESCRIPTION
Per [the change control](http://microformats.org/wiki/microformats2-parsing#change_control), I have earlier opened [an issue to standardise textContent](https://github.com/microformats/microformats2-parsing/issues/15) and [proposed a resolution](https://github.com/microformats/microformats2-parsing/issues/15#issuecomment-375595529). This is the implementation of that resolution in the parser, so it can be tested and iterated upon before possibly being included in the specification.

This PHP parser was already using a special `innerText` method, but it was not adopted by any other parsers nor did it look like anyone wanted to write it out as part of the microformats parsing specification. This method was based on [a text function](https://github.com/glennjones/microformat-shiv/blob/d4bd5ea14b48699480a2af86b3cc89c4998f8927/lib/text.js) of microformat-shiv, which in its turn was an emulation of Internet Explorer behaviour.

Things of note:

1. This replaces the old `textContent` and `innerText` methods. There is no replacement for `innerText`, the new `textContent` is the public method for extracting a plain text value from an element.
   
   The second new method `elementToString` is set to private as it should not be called outside of `textContent`. It exists on its own only so it can recursively call itself.
   
2. Whenever `textContent` is called it is no longer wrapped in a `unicodeTrim` call. Trimming is handled by the algorithm itself. If it turns out the current trimming in the algorithm isn’t sufficient in practice, we should revise the algorithm.
   
3. The new `PlainTextTest` currently validates all 9 examples from [aaronpk/microformats-whitespace-tests](https://github.com/aaronpk/microformats-whitespace-tests).
   
4. This broke 3 parser tests, which have been resolved:
    1. `ParseImpliedTest::testParsesImpliedNameConsistentWithPName` expected a line break in the `name` property. With the new algorithm, line breaks are collapsed into spaces the same way browsers would do.
    2. `ParserTest::testParseEResolvesRelativeLinks` expected two spaces in the plain text `value` of the `content` property. With the new algorithm, consecutive spaces are collapsed to a single one the same way browsers would do.
    3. `ParserTest::testHtmlEncodesImpliedProperties` was… just wrong? It expected only the string `<name>` as the value of the `name` property through implied rules. And somehow it had to sidestep the `<img>` element completely to do so. I don’t know why the previous parsing even allowed that.