### PR TITLE
Add support and test for alternative HTML5 parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,9 @@ php:
   - 7.1
   - 7.2
   - nightly
+env:
+  - COMPOSER_REQUIRE="echo"
+  - COMPOSER_REQUIRE="composer require masterminds/html5"
+install:
+  - $COMPOSER_REQUIRE
 before_script: composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - 7.2
   - nightly
 env:
-  - COMPOSER_REQUIRE="echo"
+  - COMPOSER_REQUIRE=""
   - COMPOSER_REQUIRE="composer require masterminds/html5"
 install:
   - $COMPOSER_REQUIRE

--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -337,8 +337,13 @@ class Parser {
 	public function __construct($input, $url = null, $jsonMode = false) {
 		libxml_use_internal_errors(true);
 		if (is_string($input)) {
-			$doc = new DOMDocument();
-			@$doc->loadHTML(unicodeToHtmlEntities($input));
+			if (class_exists('Masterminds\\HTML5')) {
+			    $doc = new \Masterminds\HTML5(array('disable_html_ns' => true));
+			    $doc = $doc->loadHTML($input);
+			} else {
+				$doc = new DOMDocument();
+				@$doc->loadHTML(unicodeToHtmlEntities($input));
+			}
 		} elseif (is_a($input, 'DOMDocument')) {
 			$doc = $input;
 		} else {

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     },
     "license": "CC0-1.0",
     "suggest": {
-        "barnabywalters/mf-cleaner": "To more easily handle the canonical data php-mf2 gives you"
+        "barnabywalters/mf-cleaner": "To more easily handle the canonical data php-mf2 gives you",
+        "masterminds/html5": "Alternative HTML parser for PHP, for better HTML5 support."
     }
 }

--- a/tests/Mf2/ParserTest.php
+++ b/tests/Mf2/ParserTest.php
@@ -776,5 +776,19 @@ END;
 		$this->assertEquals(array('h-cite', 'h-entry'), $output['items'][0]['type']);
 	}
 
+	/**
+	 * The default DOMDocument parser will trip here because it does not know HTML5 elements.
+	 * @see https://html.spec.whatwg.org/#optional-tags:the-p-element
+	 **/
+	public function testHtml5OptionalPEndTag() {
+		if (!class_exists('Masterminds\\HTML5')) {
+			$this->markTestSkipped('masterminds/html5 is required for this test.');
+		}
+		$input = '<div class="h-entry"><p class="p-name">Name<article>Not Name</article></div>';
+		$output = Mf2\parse($input);
+
+		$this->assertEquals('Name', $output['items'][0]['properties']['name'][0]);
+	}
+
 }
 


### PR DESCRIPTION
Suggest the end-user to also install [masterminds/html5](https://github.com/Masterminds/html5-php). If it is installed, php-mf2 will use it instead of the default [`DOMDocument::loadHTML`](https://secure.php.net/manual/en/domdocument.loadhtml.php).

All tests pass as normal with the alternative parser. One extra test was added that simulates the problem with the default parser. This test is skipped if masterminds/html5 isn’t installed.