### PR TITLE
Move resolve step last in u-* parsing

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -618,23 +618,16 @@ class Parser {
 			$uValue = $u->getAttribute('poster');
 		} elseif ($u->tagName == 'object' and $u->hasAttribute('data')) {
 			$uValue = $u->getAttribute('data');
-		}
-
-		if (isset($uValue)) {
-			return $this->resolveUrl($uValue);
-		}
-
-		$classTitle = $this->parseValueClassTitle($u);
-
-		if ($classTitle !== null) {
-			return $classTitle;
+		} elseif (($classTitle = $this->parseValueClassTitle($u)) !== null) {
+		    $uValue = $classTitle;
 		} elseif (($u->tagName == 'abbr' or $u->tagName == 'link') and $u->hasAttribute('title')) {
-			return $u->getAttribute('title');
+			$uValue = $u->getAttribute('title');
 		} elseif (in_array($u->tagName, array('data', 'input')) and $u->hasAttribute('value')) {
-			return $u->getAttribute('value');
+			$uValue = $u->getAttribute('value');
 		} else {
-			return $this->textContent($u);
+			$uValue = $this->textContent($u);
 		}
+        return $this->resolveUrl($uValue);
 	}
 
 	/**

--- a/tests/Mf2/ParseUTest.php
+++ b/tests/Mf2/ParseUTest.php
@@ -47,7 +47,7 @@ class ParseUTest extends PHPUnit_Framework_TestCase {
 		$output = $parser->parse();
 		
 		$this->assertArrayHasKey('url', $output['items'][0]['properties']);
-		$this->assertEquals('Awesome example website', $output['items'][0]['properties']['url'][0]);
+		$this->assertEquals('http://example.com/Awesome example website', $output['items'][0]['properties']['url'][0]);
 	}
 
 	/**
@@ -294,6 +294,14 @@ END;
 
     $this->assertArrayHasKey('name', $output['items'][0]['properties']);
     $this->assertEquals('Example.com homepage', $output['items'][0]['properties']['name'][0]);
+  }
+
+  public function testResolveFromDataElement() {
+    $parser = new Parser('<div class="h-test"><data class="u-url" value="relative.html"></data></div>', 'https://example.com/index.html');
+    $output = $parser->parse();
+    
+    $this->assertArrayHasKey('url', $output['items'][0]['properties']);
+    $this->assertEquals('https://example.com/relative.html', $output['items'][0]['properties']['url'][0]);
   }
 
 }


### PR DESCRIPTION
This matches the proposed parsing change from microformats/microformats2-parsing#10.

Note that one old test had to be updated, because it tested for `textContent` being returned as is. And now we resolve strings gotten from there too.

If I am reading the URL spec right though, the URL we are returning isn’t actually a valid URL. Spaces are in the [path percent-encode set](https://url.spec.whatwg.org/#path-percent-encode-set) so should be replaced with `%20` … I think. Ideas?