### PR TITLE
Use stdClass when a microformat has no properties

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -1122,6 +1122,11 @@ class Parser {
 		// Make sure things are unique and in alphabetical order
 		$mfTypes = array_unique($mfTypes);
 		sort($mfTypes);
+		
+		// Properties should be an object when JSON serialised
+		if (empty($return) and $this->jsonMode) {
+			$return = new stdClass();
+		}
 
 		// Phew. Return the final result.
 		$parsed = array(

--- a/tests/Mf2/CombinedMicroformatsTest.php
+++ b/tests/Mf2/CombinedMicroformatsTest.php
@@ -417,5 +417,17 @@ END;
 		$this->assertArrayNotHasKey('category', $output['items'][1]['properties']);
 	}
 
+	/**
+	 * JSON-mode should return an empty stdClass when a microformat has no properties.
+	 * @see https://github.com/indieweb/php-mf2/issues/171
+	 */
+	public function testEmptyPropertiesObjectInJSONMode() {
+		$input = '<div class="h-feed"><div class="h-entry"></div></div>';
+		$parser = new Parser($input, null, true);
+		$output = $parser->parse();
+		$this->assertInstanceOf(\stdClass::class, $output['items'][0]['properties']);
+		$this->assertSame('{}', json_encode($output['items'][0]['properties']));
+	}
+
 }
 

--- a/tests/Mf2/CombinedMicroformatsTest.php
+++ b/tests/Mf2/CombinedMicroformatsTest.php
@@ -425,7 +425,7 @@ END;
 		$input = '<div class="h-feed"><div class="h-entry"></div></div>';
 		$parser = new Parser($input, null, true);
 		$output = $parser->parse();
-		$this->assertInstanceOf(\stdClass::class, $output['items'][0]['properties']);
+		$this->assertInstanceOf('\stdClass', $output['items'][0]['properties']);
 		$this->assertSame('{}', json_encode($output['items'][0]['properties']));
 	}
 

--- a/tests/Mf2/CombinedMicroformatsTest.php
+++ b/tests/Mf2/CombinedMicroformatsTest.php
@@ -423,10 +423,16 @@ END;
 	 */
 	public function testEmptyPropertiesObjectInJSONMode() {
 		$input = '<div class="h-feed"><div class="h-entry"></div></div>';
+		// Try in JSON-mode: expect the raw PHP to be an stdClass instance that serializes to an empty object.
 		$parser = new Parser($input, null, true);
 		$output = $parser->parse();
 		$this->assertInstanceOf('\stdClass', $output['items'][0]['properties']);
 		$this->assertSame('{}', json_encode($output['items'][0]['properties']));
+		// Repeat in non-JSON-mode: expect the raw PHP to be an array. Check that its serialization is not what we need for mf2 JSON.
+		$parser = new Parser($input, null, false);
+		$output = $parser->parse();
+		$this->assertInternalType('array', $output['items'][0]['properties']);
+		$this->assertSame('[]', json_encode($output['items'][0]['properties']));
 	}
 
 }


### PR DESCRIPTION
Fixes #171. Test based on the issue included.