### PR TITLE
Fix XPaths used in implied photo parsing

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -1171,8 +1171,8 @@ class Parser {
 		$xpaths = array(
 			'./img',
 			'./object',
-			'./*[count(preceding-sibling::*)+count(following-sibling::*)=0]/img',
-			'./*[count(preceding-sibling::*)+count(following-sibling::*)=0]/object',
+			'./*[not(contains(concat(" ", @class), " h-"))]/img[count(preceding-sibling::img)+count(following-sibling::img)=0]',
+			'./*[not(contains(concat(" ", @class), " h-"))]/object[count(preceding-sibling::object)+count(following-sibling::object)=0]',
 		);
 
 		foreach ($xpaths as $path) {

--- a/tests/Mf2/ParseImpliedTest.php
+++ b/tests/Mf2/ParseImpliedTest.php
@@ -274,6 +274,26 @@ class ParseImpliedTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @see https://github.com/indieweb/php-mf2/issues/176
+	 */
+	public function testIgnoredPhotoImgInNestedH() {
+		$input = '<div class="h-entry"> <div class="u-comment h-cite"> <img src="/image.jpg"> </div> </div>';
+		$result = Mf2\parse($input);
+
+		$this->assertArrayNotHasKey('photo', $result['items'][0]['properties']);
+	}
+
+	/**
+	 * @see https://github.com/indieweb/php-mf2/issues/176
+	 */
+	public function testIgnoredPhotoObjectInNestedH() {
+		$input = '<div class="h-entry"> <div class="u-comment h-cite"> <object data="/image2.jpg">John Doe</object> </div> </div>';
+		$result = Mf2\parse($input);
+
+		$this->assertArrayNotHasKey('photo', $result['items'][0]['properties']);
+	}
+
+	/**
 	 * Imply properties only on explicit h-x class name root microformat element (no backcompat roots)
 	 * @see http://microformats.org/wiki/microformats2-parsing#parsing_for_implied_properties
 	 */


### PR DESCRIPTION
The XPaths in `parseImpliedPhoto()` weren't quite right. The parse in #176 was implying the photo from the nested `h-*` incorrectly.

Fixes #176.