### PR TITLE
Fix parsing multiple mf1 roots on same element

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -1506,7 +1506,7 @@ class Parser {
 			$mf1Classes = array_intersect($classes, array_keys($this->classicRootMap));
 		}
 
-		$el_has_mf2 = $this->hasRootMf2($el);
+		$elHasMf2 = $this->hasRootMf2($el);
 
 		foreach ($mf1Classes as $classname) {
 			// special handling for specific properties
@@ -1602,7 +1602,7 @@ class Parser {
 				}
 			}
 
-			if ( empty($context) && isset($this->classicRootMap[$classname]) && !$el_has_mf2 ) {
+			if ( empty($context) && isset($this->classicRootMap[$classname]) && !$elHasMf2 ) {
 				$this->addMfClasses($el, $this->classicRootMap[$classname]);
 			}
 		}

--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -1506,6 +1506,8 @@ class Parser {
 			$mf1Classes = array_intersect($classes, array_keys($this->classicRootMap));
 		}
 
+		$el_has_mf2 = $this->hasRootMf2($el);
+
 		foreach ($mf1Classes as $classname) {
 			// special handling for specific properties
 			switch ( $classname )
@@ -1600,7 +1602,7 @@ class Parser {
 				}
 			}
 
-			if ( empty($context) && isset($this->classicRootMap[$classname]) && !$this->hasRootMf2($el) ) {
+			if ( empty($context) && isset($this->classicRootMap[$classname]) && !$el_has_mf2 ) {
 				$this->addMfClasses($el, $this->classicRootMap[$classname]);
 			}
 		}

--- a/tests/Mf2/ClassicMicroformatsTest.php
+++ b/tests/Mf2/ClassicMicroformatsTest.php
@@ -971,5 +971,26 @@ Two perfectly poached eggs and a thin slice of tasty, French ham rest on a circl
 		$this->assertContains('phpmf2', $output['items'][1]['properties']['category']);
 		$this->assertContains('mf2py', $output['items'][1]['properties']['category']);
 	}
+
+	/**
+	 * Upgrade multiple mf1 roots on the same element
+	 * @see https://github.com/indieweb/php-mf2/issues/156
+	 */
+	public function testBackcompatMultipleRoots() {
+		$input = '<article class="vevent hentry">
+    <span class="entry-title">h-entry name</span>
+    <span class="summary">h-event name</span>
+</article>';
+		$result = Mf2\parse($input);
+
+		$this->assertCount(2, $result['items'][0]['type']);
+		$this->assertContains('h-event', $result['items'][0]['type']);
+		$this->assertContains('h-entry', $result['items'][0]['type']);
+		$this->assertArrayHasKey('name', $result['items'][0]['properties']);
+		$this->assertCount(2, $result['items'][0]['properties']['name']);
+		$this->assertContains('h-event name', $result['items'][0]['properties']['name']);
+		$this->assertContains('h-entry name', $result['items'][0]['properties']['name']);
+	}
+
 }
 


### PR DESCRIPTION
Fixes #156 

Cause of issue was checking `$el` within a loop that adds mf2 classes. Needed to keep track of the initial state of the element's classes.