### PR TITLE
PHP 5.6 Dockerfile Refresh

### DIFF
--- a/php56.Dockerfile
+++ b/php56.Dockerfile
@@ -4,7 +4,7 @@ COPY --from=composer:2.2.12 /usr/bin/composer /usr/bin/composer
 
 RUN apt-get update && apt-get install -y \
       zip \
-    && rm -rf /var/cache/apt/
+    && rm -rf /var/cache/apt/lists/*
 
 RUN pecl install xdebug-2.5.5 \
     && docker-php-ext-enable xdebug

--- a/php56.Dockerfile
+++ b/php56.Dockerfile
@@ -2,6 +2,10 @@ FROM php:5.6-cli
 
 COPY --from=composer:2.2.23 /usr/bin/composer /usr/bin/composer
 
+RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list \
+    && sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list \
+    && sed -i /stretch-updates/d /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y \
       zip \
     && rm -rf /var/cache/apt/lists/*

--- a/php56.Dockerfile
+++ b/php56.Dockerfile
@@ -1,6 +1,6 @@
 FROM php:5.6-cli
 
-COPY --from=composer:2.2.12 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.2.23 /usr/bin/composer /usr/bin/composer
 
 RUN apt-get update && apt-get install -y \
       zip \


### PR DESCRIPTION
I noticed that the `php56.dockerfile` no longer builds because the debian stretch repos have been relocated to the archives. This PR refreshes the php56.dockerfile so that it will build again.

