### PR TITLE
Tests: fail on deprecation notices

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,8 +52,8 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '${{ matrix.php }}'
-        tools: composer
-        extensions: 'xdebug'
+        ini-values: zend.assertions=1, error_reporting=-1, display_errors=On, log_errors_max_len=0
+        coverage: 'xdebug'
     - uses: actions/checkout@v4
 
     - name: Install Composer dependencies & cache dependencies

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit bootstrap="tests/Mf2/bootstrap.php">
+<phpunit bootstrap="tests/Mf2/bootstrap.php" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="php-mf2">
 			<directory suffix="Test.php">tests/Mf2</directory>


### PR DESCRIPTION
This (small) change needs a little explaining....

First of all, the `setup-php` action, by default uses a "production"-type ini file. This means that `error_reporting` is set to `E_ALL & ~E_DEPRECATED & ~E_STRICT` and `display_errors` is set to `Off`.

For the purposes of CI, I'd recommend running with `-1` (always include all error levels on all PHP versions) and `display_errors=On` to ensure **all** PHP notices are shown.

This is now fixed by adding the `ini-values` setting to `setup-php`.

I've also made minor other tweaks to the `setup-php` config:
* `tools: composer` is not needed as Composer is installed by default.
* `extension: xdebug` is not the correct way to enable `xdebug` for code coverage. `coverage: xdebug` is (and is Xdebug cross-version compatible for Xdebug 2 and 3).

Second of all, a change was made in PHPUnit 8.5.21 and 9.5.10, which changes the default value of the PHPUnit `convertDeprecationsToExceptions` attribute from `true` to `false`, meaning that tests would no longer fail on deprecation notices.

Not great for open source packages which generally need to handle deprecations in a timely matter so as not to block other packages.

So adding the `convertDeprecationsToExceptions` attribute and explicitly setting the value to `true` brings back the old behaviour and will allow for failing the tests on deprecation notices.