### PR TITLE
Remove implicit nullability deprecated in PHP 8.4

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -1380,10 +1380,15 @@ class Parser {
 	/**
 	 * Kicks off the parsing routine
 	 * @param bool $convertClassic whether to do backcompat parsing on microformats1. Defaults to true.
-	 * @param DOMElement $context optionally specify an element from which to parse microformats
+	 * @param ?DOMElement $context optionally specify an element from which to parse microformats
 	 * @return array An array containing all the microformats found in the current document
 	 */
-	public function parse($convertClassic = true, DOMElement $context = null) {
+	public function parse($convertClassic = true) {
+		$context = func_num_args() > 1 ? func_get_arg(1) : null;
+		if ($context !== null && !$context instanceof DOMElement) {
+			throw new \InvalidArgumentException(__METHOD__ . ': Argument #1 ($context) must be of type ?DOMElement, ' . gettype($context) . ' given');
+		}
+
 		$this->convertClassic = $convertClassic;
 		$mfs = $this->parse_recursive($context);
 
@@ -1407,11 +1412,21 @@ class Parser {
 	/**
 	 * Parse microformats recursively
 	 * Keeps track of whether inside a backcompat root or not
-	 * @param DOMElement $context: node to start with
+	 * @param ?DOMElement $context: node to start with
 	 * @param int $depth: recursion depth
 	 * @return array
 	 */
-	public function parse_recursive(DOMElement $context = null, $depth = 0) {
+	public function parse_recursive() {
+		$numArgs = func_num_args();
+		$context = $numArgs > 0 ? func_get_arg(0) : null;
+		$depth = $numArgs > 1 ? func_get_arg(1) : 0;
+		if ($context !== null && !$context instanceof DOMElement) {
+			throw new \InvalidArgumentException(__METHOD__ . ': Argument #0 ($context) must be of type ?DOMElement, ' . gettype($context) . ' given');
+		}
+		if ($depth !== null && !is_int($depth)) {
+			throw new \InvalidArgumentException(__METHOD__ . ': Argument #1 ($depth) must be of type int, ' . gettype($depth) . ' given');
+		}
+
 		$mfs = array();
 		$mfElements = $this->getRootMF($context);
 
@@ -1513,10 +1528,15 @@ class Parser {
 
 	/**
 	 * Get the root microformat elements
-	 * @param DOMElement $context
+	 * @param ?DOMElement $context
 	 * @return DOMNodeList
 	 */
-	public function getRootMF(DOMElement $context = null) {
+	public function getRootMF() {
+		$context = func_num_args() > 0 ? func_get_arg(0) : null;
+		if ($context !== null && !$context instanceof DOMElement) {
+			throw new \InvalidArgumentException(__METHOD__ . ': Argument #0 ($context) must be of type ?DOMElement, ' . gettype($context) . ' given');
+		}
+
 		// start with mf2 root class name xpath
 		$xpaths = array(
 			'(php:function("\\Mf2\\classHasMf2RootClassname", normalize-space(@class)))'


### PR DESCRIPTION
PHP 8.4 deprecates implicitly nullable parameters, i.e. typed parameter with a `null` default value, which are not explicitly declared as nullable.
See <https://wiki.php.net/rfc/deprecate-implicitly-nullable-types>

Ideally, we would just change the type hint `?DOMElement` but <https://wiki.php.net/rfc/nullable_types> was only introduced in PHP 7.1, while we still support PHP 5.6.

This patch is a somewhat hacky alternative to <https://github.com/microformats/php-mf2/pull/264> that fixes those warnings without breaking backwards compatibility or removing PHP < 7.1 support. We remove the offending formal arguments in favour of obtaining them with `func_get_arg()` and checking their type ourselves. The PHPDoc param annotations were updated to match the actual types of the now virtual arguments.

The downside is that it removes PHP 7.4’s parameter contravariance checks (https://wiki.php.net/rfc/covariant-returns-and-contravariant-parameters) so future re-introduction of the formal arguments would be a BC break.
