### PR TITLE
unicodeTrim: Fix PHP 8.2 deprecation

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -111,9 +111,7 @@ function collapseWhitespace($str) {
 }
 
 function unicodeTrim($str) {
-	// this is cheating. TODO: find a better way if this causes any problems
-	$str = str_replace(mb_convert_encoding('&nbsp;', 'UTF-8', 'HTML-ENTITIES'), ' ', $str);
-	return preg_replace('/^\s+|\s+$/', '', $str);
+	return preg_replace('/^\s+|\s+$/u', '', $str);
 }
 
 /**

--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -113,8 +113,7 @@ function collapseWhitespace($str) {
 function unicodeTrim($str) {
 	// this is cheating. TODO: find a better way if this causes any problems
 	$str = str_replace(mb_convert_encoding('&nbsp;', 'UTF-8', 'HTML-ENTITIES'), ' ', $str);
-	$str = preg_replace('/^\s+/', '', $str);
-	return preg_replace('/\s+$/', '', $str);
+	return preg_replace('/^\s+|\s+$/', '', $str);
 }
 
 /**


### PR DESCRIPTION
mbstring extension in PHP 8.2 deprecates `HTML-ENTITIES` encoding:
https://php.watch/versions/8.2/mbstring-qprint-base64-uuencode-html-entities-deprecated

However, there is no need to use it to the UTF-8 representation of NBSP, one can just directly use `\u{0a}` (or `\xc2\x0a` for PHP < 7.0).

Or, even better, we can enable `PCRE_UTF8` mode:

https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php

That will remove all Unicode whitespace characters, not just the ASCII ones and nbsp because `u` modifier in PHP enables `PCRE_UCP` as well `PCRE_UTF` options:

https://github.com/php/doc-en/issues/2831

It is supposed to be available since PHP 5.1:

https://www.phpbb.com/community/viewtopic.php?t=733515
