### PR TITLE
unicodeToHtmlEntities: Fix PHP 8.2 deprecation

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -93,7 +93,12 @@ function fetch($url, $convertClassic = true, &$curlInfo=null) {
  * @return string
  */
 function unicodeToHtmlEntities($input) {
-	return mb_convert_encoding($input, 'HTML-ENTITIES', mb_detect_encoding($input));
+	// Convert all non-ASCII characters to HTML numeric entities.
+	$convmap = [
+		0x80, 0x1FFFFF, 0, 0x10FFFF,
+	];
+
+	return mb_encode_numericentity($input, $convmap, mb_detect_encoding($input), true);
 }
 
 /**


### PR DESCRIPTION
mbstring extension in PHP 8.2 deprecates `HTML-ENTITIES` encoding:
https://php.watch/versions/8.2/mbstring-qprint-base64-uuencode-html-entities-deprecated

Let’s switch to non-deprecated function:
https://www.php.net/manual/en/function.mb-encode-numericentity.php
