### PR TITLE
Add PHPCS coding standards and fix violations

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -62,7 +62,7 @@ function parse($input, $url = null, $convertClassic = true) {
  * @param &array $curlInfo (optional) the results of curl_getinfo will be placed in this variable for debugging
  * @return array|null canonical microformats2 array structure on success, null on failure
  */
-function fetch($url, $convertClassic = true, &$curlInfo=null) {
+function fetch($url, $convertClassic = true, &$curlInfo = null) {
 	$ch = curl_init();
 	curl_setopt($ch, CURLOPT_URL, $url);
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
@@ -127,7 +127,7 @@ function unicodeTrim($str) {
  * @param string $prefix The prefix to look for
  * @return string|array The prefixed name of the first microfomats class found or false
  */
-function mfNamesFromClass($class, $prefix='h-') {
+function mfNamesFromClass($class, $prefix = 'h-') {
 	$class = str_replace(array(' ', '	', "\n"), ' ', $class);
 	$classes = explode(' ', $class);
 	$classes = preg_grep('#^(h|p|u|dt|e)-([a-z0-9]+-)?[a-z]+(-[a-z]+)*$#', $classes);
@@ -366,7 +366,7 @@ class Parser {
 			if (empty($input)) {
 					$input = $emptyDocDefault;
 			}
-				
+
 			if (class_exists('Masterminds\\HTML5')) {
 					$doc = new \Masterminds\HTML5(array('disable_html_ns' => true));
 					$doc = $doc->loadHTML($input);
@@ -482,7 +482,7 @@ class Parser {
 	 * @param bool $implied
 	 * @see https://wiki.zegnat.net/media/textparsing.html
 	 **/
-	public function textContent(DOMElement $element, $implied=false)
+	public function textContent(DOMElement $element, $implied = false)
 	{
 				return preg_replace(
 						'/(^[\t\n\f\r ]+| +(?=\n)|(?<=\n) +| +(?= )|[\t\n\f\r ]+$)/',
@@ -490,7 +490,7 @@ class Parser {
 						$this->elementToString($element, $implied)
 				);
 	}
-	private function elementToString(DOMElement $input, $implied=false)
+	private function elementToString(DOMElement $input, $implied = false)
 	{
 			$output = '';
 			foreach ($input->childNodes as $child) {
@@ -1179,7 +1179,7 @@ class Parser {
 		);
 
 		if(trim($e->getAttribute('id')) !== '') {
-			$parsed['id'] = trim($e->getAttribute("id"));
+			$parsed['id'] = trim($e->getAttribute('id'));
 		}
 
 		if($this->lang) {
@@ -1385,7 +1385,7 @@ class Parser {
 	 */
 	public function parse($convertClassic = true, DOMElement $context = null) {
 		$this->convertClassic = $convertClassic;
-		$mfs = $this->parse_recursive($context);
+		$mfs = $this->parseRecursive($context);
 
 		// Parse rels
 		list($rels, $rel_urls, $alternates) = $this->parseRelsAndAlternates();
@@ -1411,7 +1411,7 @@ class Parser {
 	 * @param int $depth: recursion depth
 	 * @return array
 	 */
-	public function parse_recursive(DOMElement $context = null, $depth = 0) {
+	public function parseRecursive(DOMElement $context = null, $depth = 0) {
 		$mfs = array();
 		$mfElements = $this->getRootMF($context);
 
@@ -1422,7 +1422,7 @@ class Parser {
 				$this->backcompat($node);
 			}
 
-			$recurse = $this->parse_recursive($node, $depth + 1);
+			$recurse = $this->parseRecursive($node, $depth + 1);
 
 			// set bool flag for nested mf
 			$has_nested_mf = (bool) $recurse;
@@ -1486,6 +1486,18 @@ class Parser {
 		return $mfs;
 	}
 
+	/**
+	 * Parse microformats recursively (deprecated)
+	 * @param DOMElement $context: node to start with
+	 * @param int $depth: recursion depth
+	 * @return array
+	 * @deprecated Use parseRecursive() instead
+	 */
+	// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+	public function parse_recursive(DOMElement $context = null, $depth = 0) {
+		return $this->parseRecursive($context, $depth);
+	}
+
 
 	/**
 	 * Parse From ID
@@ -1502,7 +1514,7 @@ class Parser {
 	 * @param bool $htmlSafe = false whether or not to HTML-encode angle brackets in non e-* properties
 	 * @return array
 	 */
-	public function parseFromId($id, $convertClassic=true) {
+	public function parseFromId($id, $convertClassic = true) {
 		$matches = $this->xpath->query("//*[@id='{$id}']");
 
 		if (empty($matches))

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,7 +1,49 @@
 <?xml version="1.0"?>
 <ruleset name="PHP-MF2">
-	<description>PHP-MF2 Standards</description>
+	<description>PHP-MF2 Coding Standards</description>
+
 	<file>./Mf2/Parser.php</file>
+	<file>./tests/</file>
+
+	<!-- PHP Compatibility -->
 	<rule ref="PHPCompatibility"/>
 	<config name="testVersion" value="5.6-"/>
+
+	<!-- Tabs for indentation -->
+	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
+
+	<!-- PSR-1 naming conventions -->
+	<rule ref="PSR1.Classes.ClassDeclaration"/>
+	<rule ref="PSR1.Methods.CamelCapsMethodName">
+		<!-- Allow date format test methods (e.g., testYYYY_MM_DD__HH_MM) -->
+		<exclude-pattern>tests/Mf2/ParseDTTest.php</exclude-pattern>
+	</rule>
+
+	<!-- No trailing whitespace -->
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
+
+	<!-- Single space after cast -->
+	<rule ref="Generic.Formatting.SpaceAfterCast"/>
+
+	<!-- PHP opening tag -->
+	<rule ref="Generic.PHP.DisallowShortOpenTag"/>
+
+	<!-- Use lowercase for PHP keywords -->
+	<rule ref="Generic.PHP.LowerCaseKeyword"/>
+	<rule ref="Generic.PHP.LowerCaseConstant"/>
+
+	<!-- Spaces around equals in function declarations -->
+	<rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
+		<properties>
+			<property name="equalsSpacing" value="1"/>
+		</properties>
+	</rule>
+
+	<!-- Single quotes when no variable substitution needed -->
+	<rule ref="Squiz.Strings.DoubleQuoteUsage.NotRequired"/>
+
+	<!-- Allow multiple classes in test files (helper classes) -->
+	<rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
 </ruleset>

--- a/tests/Mf2/ClassicMicroformatsTest.php
+++ b/tests/Mf2/ClassicMicroformatsTest.php
@@ -18,6 +18,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  * Mainly based off BC tables on https://microformats.org/wiki/microformats2#v2_vocabularies
  */
 class ClassicMicroformatsTest extends TestCase {
+	// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
 	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
@@ -147,7 +148,7 @@ EOT;
 	/**
 	 * @see https://github.com/indieweb/php-mf2/issues/81
 	 */
-	public function test_vevent() {
+	public function testVevent() {
 		$input = <<< EOT
 <div class="vevent">
 <h3 class="summary">XYZ Project Review</h3>
@@ -896,7 +897,7 @@ END;
 	}
 
   public function testHEntryRelTagInContent() {
-    $input = <<< END
+	$input = <<< END
 <article class="hentry">
   <div class="entry-content">
     Entry content should not include the generated <code>data</code> element for rel tag backcompat <a href="/tag/test" rel="tag">test</a>
@@ -904,13 +905,13 @@ END;
 </article>
 END;
 
-    $parser = new Parser($input);
-    $output = $parser->parse();
-    $item = $output['items'][0];
+	$parser = new Parser($input);
+	$output = $parser->parse();
+	$item = $output['items'][0];
 
-    $this->assertEquals(['test'], $item['properties']['category']);
-    $this->assertEquals('Entry content should not include the generated data element for rel tag backcompat test', $item['properties']['content'][0]['value']);
-    $this->assertEquals('Entry content should not include the generated <code>data</code> element for rel tag backcompat <a href="/tag/test" rel="tag">test</a>', $item['properties']['content'][0]['html']);
+	$this->assertEquals(['test'], $item['properties']['category']);
+	$this->assertEquals('Entry content should not include the generated data element for rel tag backcompat test', $item['properties']['content'][0]['value']);
+	$this->assertEquals('Entry content should not include the generated <code>data</code> element for rel tag backcompat <a href="/tag/test" rel="tag">test</a>', $item['properties']['content'][0]['html']);
   }
 
 	/**

--- a/tests/Mf2/CombinedMicroformatsTest.php
+++ b/tests/Mf2/CombinedMicroformatsTest.php
@@ -18,6 +18,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
 class CombinedMicroformatsTest extends TestCase {
 	use AssertIsType;
 
+	// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
 	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
@@ -294,7 +295,7 @@ class CombinedMicroformatsTest extends TestCase {
 	    "rels":[],
 	    "rel-urls": []
 	  }';
-	  	$mf = Mf2\parse($input);
+		$mf = Mf2\parse($input);
 
 		$this->assertJsonStringEqualsJsonString(json_encode($mf), $expected);
 		$this->assertEquals($mf['items'][0]['properties']['comment'][0]['value'], 'https://example.com/post1234');
@@ -345,18 +346,18 @@ class CombinedMicroformatsTest extends TestCase {
 	}
 
   public function testNoUrlFromRelOnMf2() {
-    $input = <<< END
+	$input = <<< END
 <div class="h-entry">
 <p> <a href="/article" rel="bookmark" class="p-name">Title of Post</a> </p>
 <div class="e-content"><p> This is the post </p> </div>
 </div>
 END;
-    $parser = new Parser($input);
-    $output = $parser->parse();
+	$parser = new Parser($input);
+	$output = $parser->parse();
 
-    $this->assertArrayHasKey('name', $output['items'][0]['properties']);
-    $this->assertArrayHasKey('content', $output['items'][0]['properties']);
-    $this->assertArrayNotHasKey('url', $output['items'][0]['properties']);
+	$this->assertArrayHasKey('name', $output['items'][0]['properties']);
+	$this->assertArrayHasKey('content', $output['items'][0]['properties']);
+	$this->assertArrayNotHasKey('url', $output['items'][0]['properties']);
   }
 
 	/**
@@ -378,7 +379,7 @@ END;
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('value', $output['items'][0]['properties']['location'][0]);
-		$this->assertEquals("Portland, Oregon • 44°F", $output['items'][0]['properties']['location'][0]['value']);
+		$this->assertEquals('Portland, Oregon • 44°F', $output['items'][0]['properties']['location'][0]['value']);
 	}
 
 	/**

--- a/tests/Mf2/MicroformatsTestSuiteTest.php
+++ b/tests/Mf2/MicroformatsTestSuiteTest.php
@@ -6,164 +6,164 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 final class TestSuiteParser extends \Mf2\Parser
 {
-    /** Actually textContent from before the whitespace normalisation merge (e8da04f93d548d26287a8980eca4216639cbc61d) */
-    public function textContent(\DOMElement $el, $dummy=false) {
-        $excludeTags = array('noframe', 'noscript', 'script', 'style', 'frames', 'frameset');
+	/** Actually textContent from before the whitespace normalisation merge (e8da04f93d548d26287a8980eca4216639cbc61d) */
+	public function textContent(\DOMElement $el, $dummy = false) {
+		$excludeTags = array('noframe', 'noscript', 'script', 'style', 'frames', 'frameset');
 
-        if (isset($el->tagName) and in_array(strtolower($el->tagName), $excludeTags)) {
-            return '';
-        }
+		if (isset($el->tagName) and in_array(strtolower($el->tagName), $excludeTags)) {
+			return '';
+		}
 
-        $this->_resolveChildUrls($el);
+		$this->_resolveChildUrls($el);
 
-        $clonedEl = $el->cloneNode(true);
+		$clonedEl = $el->cloneNode(true);
 
-        foreach ($this->xpath->query('.//img', $clonedEl) as $imgEl) {
-            if ($imgEl->hasAttribute('alt')) {
-                $replacement = $imgEl->getAttribute('alt');
-            } else if ($imgEl->hasAttribute('src')) {
-                $replacement = ' ' . $imgEl->getAttribute('src') . ' ';
-            } else {
-                $replacement = ''; // Bye bye IMG element.
-            }
-            $newNode = $this->doc->createTextNode($replacement);
-            $imgEl->parentNode->replaceChild($newNode, $imgEl);
-        }
+		foreach ($this->xpath->query('.//img', $clonedEl) as $imgEl) {
+			if ($imgEl->hasAttribute('alt')) {
+				$replacement = $imgEl->getAttribute('alt');
+			} else if ($imgEl->hasAttribute('src')) {
+				$replacement = ' ' . $imgEl->getAttribute('src') . ' ';
+			} else {
+				$replacement = ''; // Bye bye IMG element.
+			}
+			$newNode = $this->doc->createTextNode($replacement);
+			$imgEl->parentNode->replaceChild($newNode, $imgEl);
+		}
 
-        foreach ($excludeTags as $tagName) {
-            foreach ($this->xpath->query(".//{$tagName}", $clonedEl) as $elToRemove) {
-                $elToRemove->parentNode->removeChild($elToRemove);
-            }
-        }
+		foreach ($excludeTags as $tagName) {
+			foreach ($this->xpath->query(".//{$tagName}", $clonedEl) as $elToRemove) {
+				$elToRemove->parentNode->removeChild($elToRemove);
+			}
+		}
 
-        return \Mf2\unicodeTrim($clonedEl->textContent);
-    }
+		return \Mf2\unicodeTrim($clonedEl->textContent);
+	}
 
-    // Hack. Old textContent requires "resolveChildUrls", but that method is private.
-    private $__resolveChildUrls = null;
-    private function _resolveChildUrls(\DOMElement $element) {
-        if (null === $this->__resolveChildUrls) {
-            $reflectUpon = new \ReflectionClass($this);
-            $this->__resolveChildUrls = $reflectUpon->getMethod('resolveChildUrls');
-            $this->__resolveChildUrls->setAccessible(true);
-        }
-        return $this->__resolveChildUrls->invoke($this, $element);
-    }
+	// Hack. Old textContent requires "resolveChildUrls", but that method is private.
+	private $__resolveChildUrls = null;
+	private function _resolveChildUrls(\DOMElement $element) {
+		if (null === $this->__resolveChildUrls) {
+			$reflectUpon = new \ReflectionClass($this);
+			$this->__resolveChildUrls = $reflectUpon->getMethod('resolveChildUrls');
+			$this->__resolveChildUrls->setAccessible(true);
+		}
+		return $this->__resolveChildUrls->invoke($this, $element);
+	}
 }
 
 class MicroformatsTestSuiteTest extends TestCase
 {
-    /**
-     * @dataProvider mf1TestsProvider
-     * @group microformats/tests/mf1
-     */
-    public function testMf1FromTestSuite($input, $expectedOutput)
-    {
-        $parser = new TestSuiteParser($input, 'http://example.com/');
-        $this->assertEquals(
-            $this->makeComparible(json_decode($expectedOutput, true)),
-            $this->makeComparible(json_decode(json_encode($parser->parse()), true))
-        );
-    }
+	/**
+	 * @dataProvider mf1TestsProvider
+	 * @group microformats/tests/mf1
+	 */
+	public function testMf1FromTestSuite($input, $expectedOutput)
+	{
+		$parser = new TestSuiteParser($input, 'http://example.com/');
+		$this->assertEquals(
+			$this->makeComparible(json_decode($expectedOutput, true)),
+			$this->makeComparible(json_decode(json_encode($parser->parse()), true))
+		);
+	}
 
-    /**
-     * @dataProvider mf2TestsProvider
-     * @group microformats/tests/mf2
-     */
-    public function testMf2FromTestSuite($input, $expectedOutput, $test)
-    {
-        if ($test === 'h-event/time') {
-            $this->markTestIncomplete('This test does not match because we implement a proposed spec: https://github.com/microformats/microformats2-parsing/issues/4#issuecomment-373457720.');
-        }
+	/**
+	 * @dataProvider mf2TestsProvider
+	 * @group microformats/tests/mf2
+	 */
+	public function testMf2FromTestSuite($input, $expectedOutput, $test)
+	{
+		if ($test === 'h-event/time') {
+			$this->markTestIncomplete('This test does not match because we implement a proposed spec: https://github.com/microformats/microformats2-parsing/issues/4#issuecomment-373457720.');
+		}
 
-        $parser = new TestSuiteParser($input, 'http://example.com/');
-        $this->assertEquals(
-            $this->makeComparible(json_decode($expectedOutput, true)),
-            $this->makeComparible(json_decode(json_encode($parser->parse()), true))
-        );
-    }
+		$parser = new TestSuiteParser($input, 'http://example.com/');
+		$this->assertEquals(
+			$this->makeComparible(json_decode($expectedOutput, true)),
+			$this->makeComparible(json_decode(json_encode($parser->parse()), true))
+		);
+	}
 
-    /**
-     * @dataProvider mixedTestsProvider
-     * @group microformats/tests/mixed
-     */
-    public function testMixedFromTestSuite($input, $expectedOutput)
-    {
-        $parser = new TestSuiteParser($input, 'http://example.com/');
-        $this->assertEquals(
-            $this->makeComparible(json_decode($expectedOutput, true)),
-            $this->makeComparible(json_decode(json_encode($parser->parse()), true))
-        );
-    }
+	/**
+	 * @dataProvider mixedTestsProvider
+	 * @group microformats/tests/mixed
+	 */
+	public function testMixedFromTestSuite($input, $expectedOutput)
+	{
+		$parser = new TestSuiteParser($input, 'http://example.com/');
+		$this->assertEquals(
+			$this->makeComparible(json_decode($expectedOutput, true)),
+			$this->makeComparible(json_decode(json_encode($parser->parse()), true))
+		);
+	}
 
-    /**
-     * To make arrays coming from JSON more easily comparible by PHPUnit:
-     * * We sort arrays by key, normalising them, because JSON objects are unordered.
-     * * We json_encode strings, and cut the starting and ending ", so PHPUnit better
-     *   shows whitespace characters like tabs and newlines.
-     **/
-    public function makeComparible($array)
-    {
-        ksort($array);
-        foreach ($array as $key => $value) {
-            if (gettype($value) === 'array') {
-                $array[$key] = $this->makeComparible($value);
-            } else if (gettype($value) === 'string') {
-                $array[$key] = substr(json_encode($value), 1, -1);
-            }
-        }
-        return $array;
-    }
+	/**
+	 * To make arrays coming from JSON more easily comparible by PHPUnit:
+	 * * We sort arrays by key, normalising them, because JSON objects are unordered.
+	 * * We json_encode strings, and cut the starting and ending ", so PHPUnit better
+	 *   shows whitespace characters like tabs and newlines.
+	 **/
+	public function makeComparible($array)
+	{
+		ksort($array);
+		foreach ($array as $key => $value) {
+			if (gettype($value) === 'array') {
+				$array[$key] = $this->makeComparible($value);
+			} else if (gettype($value) === 'string') {
+				$array[$key] = substr(json_encode($value), 1, -1);
+			}
+		}
+		return $array;
+	}
 
-    /**
-     * Data provider lists all tests from a specific directory in mf2/tests.
-     **/
-    public function htmlAndJsonProvider($subFolder = '')
-    {
-        // Get the actual wanted subfolder.
-        $subFolder = '/mf2/tests/tests' . $subFolder;
-        // Ripped out of the test-suite.php code:
-        $finder = new \RegexIterator(
-            new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator(
-                dirname(__FILE__) . '/../../vendor/' . $subFolder,
-                \RecursiveDirectoryIterator::SKIP_DOTS
-            )),
-            '/^.+\.html$/i',
-            \RecursiveRegexIterator::GET_MATCH
-        );
-        // Build the array of separate tests:
-        $tests = array();
-        foreach ($finder as $key => $value) {
-            $dir = realpath(pathinfo($key, PATHINFO_DIRNAME));
-            $testname = substr($dir, strpos($dir, $subFolder) + strlen($subFolder) + 1) . '/' . pathinfo($key, PATHINFO_FILENAME);
-            $test = pathinfo($key, PATHINFO_BASENAME);
-            $result = pathinfo($key, PATHINFO_FILENAME) . '.json';
-            if (is_file($dir . '/' . $result)) {
-                $tests[$testname] = array(
-                    'input' => file_get_contents($dir . '/' . $test),
-                    'expectedOutput' => file_get_contents($dir . '/' . $result),
-                    'name' => $testname
-                );
-            }
-        }
-        return $tests;
-    }
+	/**
+	 * Data provider lists all tests from a specific directory in mf2/tests.
+	 **/
+	public function htmlAndJsonProvider($subFolder = '')
+	{
+		// Get the actual wanted subfolder.
+		$subFolder = '/mf2/tests/tests' . $subFolder;
+		// Ripped out of the test-suite.php code:
+		$finder = new \RegexIterator(
+			new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator(
+				dirname(__FILE__) . '/../../vendor/' . $subFolder,
+				\RecursiveDirectoryIterator::SKIP_DOTS
+			)),
+			'/^.+\.html$/i',
+			\RecursiveRegexIterator::GET_MATCH
+		);
+		// Build the array of separate tests:
+		$tests = array();
+		foreach ($finder as $key => $value) {
+			$dir = realpath(pathinfo($key, PATHINFO_DIRNAME));
+			$testname = substr($dir, strpos($dir, $subFolder) + strlen($subFolder) + 1) . '/' . pathinfo($key, PATHINFO_FILENAME);
+			$test = pathinfo($key, PATHINFO_BASENAME);
+			$result = pathinfo($key, PATHINFO_FILENAME) . '.json';
+			if (is_file($dir . '/' . $result)) {
+				$tests[$testname] = array(
+					'input' => file_get_contents($dir . '/' . $test),
+					'expectedOutput' => file_get_contents($dir . '/' . $result),
+					'name' => $testname
+				);
+			}
+		}
+		return $tests;
+	}
 
-    /**
-     * Following three functions are the actual dataProviders used by the test methods.
-     */
-    public function mf1TestsProvider()
-    {
-        return $this->htmlAndJsonProvider('/microformats-v1');
-    }
+	/**
+	 * Following three functions are the actual dataProviders used by the test methods.
+	 */
+	public function mf1TestsProvider()
+	{
+		return $this->htmlAndJsonProvider('/microformats-v1');
+	}
 
-    public function mf2TestsProvider()
-    {
-        return $this->htmlAndJsonProvider('/microformats-v2');
-    }
+	public function mf2TestsProvider()
+	{
+		return $this->htmlAndJsonProvider('/microformats-v2');
+	}
 
-    public function mixedTestsProvider()
-    {
-        return $this->htmlAndJsonProvider('/microformats-mixed');
-    }
+	public function mixedTestsProvider()
+	{
+		return $this->htmlAndJsonProvider('/microformats-mixed');
+	}
 }

--- a/tests/Mf2/MicroformatsWikiExamplesTest.php
+++ b/tests/Mf2/MicroformatsWikiExamplesTest.php
@@ -20,6 +20,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  * @author Barnaby Walters waterpigs.co.uk <barnaby@waterpigs.co.uk>
  */
 class MicroformatsWikiExamplesTest extends TestCase {
+	// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
 	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
@@ -39,7 +40,7 @@ class MicroformatsWikiExamplesTest extends TestCase {
 	}
 
 	public function testHandlesNullCorrectly() {
-		$input = Null;
+		$input = null;
 		$expected = '{
 	"rels": {},
 	"rel-urls": {},

--- a/tests/Mf2/ParseDTTest.php
+++ b/tests/Mf2/ParseDTTest.php
@@ -10,6 +10,7 @@ use Mf2\Parser;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class ParseDTTest extends TestCase {
+	// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
 	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
@@ -47,7 +48,6 @@ class ParseDTTest extends TestCase {
 		$input = '<div class="h-event"><data class="dt-start">2012-08-05T14:50</data></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
-
 
 		$this->assertArrayHasKey('start', $output['items'][0]['properties']);
 		$this->assertEquals('2012-08-05T14:50', $output['items'][0]['properties']['start'][0]);
@@ -93,36 +93,36 @@ class ParseDTTest extends TestCase {
    * @group parseDT
    */
   public function testParseDTHandlesTimeDatetimeAttrWithZ() {
-    $input = '<div class="h-event"><time class="dt-start" datetime="2012-08-05T14:50:00Z"></div>';
-    $parser = new Parser($input);
-    $output = $parser->parse();
+	$input = '<div class="h-event"><time class="dt-start" datetime="2012-08-05T14:50:00Z"></div>';
+	$parser = new Parser($input);
+	$output = $parser->parse();
 
-    $this->assertArrayHasKey('start', $output['items'][0]['properties']);
-    $this->assertEquals('2012-08-05T14:50:00Z', $output['items'][0]['properties']['start'][0]);
+	$this->assertArrayHasKey('start', $output['items'][0]['properties']);
+	$this->assertEquals('2012-08-05T14:50:00Z', $output['items'][0]['properties']['start'][0]);
   }
 
   /**
    * @group parseDT
    */
   public function testParseDTHandlesTimeDatetimeAttrWithTZOffset() {
-    $input = '<div class="h-event"><time class="dt-start" datetime="2012-08-05T14:50:00-0700"></div>';
-    $parser = new Parser($input);
-    $output = $parser->parse();
+	$input = '<div class="h-event"><time class="dt-start" datetime="2012-08-05T14:50:00-0700"></div>';
+	$parser = new Parser($input);
+	$output = $parser->parse();
 
-    $this->assertArrayHasKey('start', $output['items'][0]['properties']);
-    $this->assertEquals('2012-08-05T14:50:00-0700', $output['items'][0]['properties']['start'][0]);
+	$this->assertArrayHasKey('start', $output['items'][0]['properties']);
+	$this->assertEquals('2012-08-05T14:50:00-0700', $output['items'][0]['properties']['start'][0]);
   }
 
   /**
    * @group parseDT
    */
   public function testParseDTHandlesTimeDatetimeAttrWithTZOffset2() {
-    $input = '<div class="h-event"><time class="dt-start" datetime="2012-08-05T14:50:00-07:00"></div>';
-    $parser = new Parser($input);
-    $output = $parser->parse();
+	$input = '<div class="h-event"><time class="dt-start" datetime="2012-08-05T14:50:00-07:00"></div>';
+	$parser = new Parser($input);
+	$output = $parser->parse();
 
-    $this->assertArrayHasKey('start', $output['items'][0]['properties']);
-    $this->assertEquals('2012-08-05T14:50:00-07:00', $output['items'][0]['properties']['start'][0]);
+	$this->assertArrayHasKey('start', $output['items'][0]['properties']);
+	$this->assertEquals('2012-08-05T14:50:00-07:00', $output['items'][0]['properties']['start'][0]);
   }
 
 	/**
@@ -132,7 +132,6 @@ class ParseDTTest extends TestCase {
 		$input = '<div class="h-event"><time class="dt-start">2012-08-05T14:50</time></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
-
 
 		$this->assertArrayHasKey('start', $output['items'][0]['properties']);
 		$this->assertEquals('2012-08-05T14:50', $output['items'][0]['properties']['start'][0]);

--- a/tests/Mf2/ParseHtmlIdTest.php
+++ b/tests/Mf2/ParseHtmlIdTest.php
@@ -13,6 +13,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  *
  */
 class ParseHtmlIdTest extends TestCase {
+	// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
 	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}

--- a/tests/Mf2/ParseImpliedTest.php
+++ b/tests/Mf2/ParseImpliedTest.php
@@ -13,6 +13,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  * @todo some of these can be made into single tests with dataProviders
  */
 class ParseImpliedTest extends TestCase {
+	// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
 	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
@@ -147,22 +148,22 @@ class ParseImpliedTest extends TestCase {
 	}
 
   public function testParsesImpliedUUrlWithExplicitName() {
-    $input = '<span class="h-card"><a href="https://example.com/" class="p-name">Some Name</a></span>';
-    $parser = new Parser($input);
-    $output = $parser->parse();
+	$input = '<span class="h-card"><a href="https://example.com/" class="p-name">Some Name</a></span>';
+	$parser = new Parser($input);
+	$output = $parser->parse();
 
-    $this->assertArrayHasKey('url', $output['items'][0]['properties']);
-    $this->assertEquals('https://example.com/', $output['items'][0]['properties']['url'][0]);
+	$this->assertArrayHasKey('url', $output['items'][0]['properties']);
+	$this->assertEquals('https://example.com/', $output['items'][0]['properties']['url'][0]);
   }
 
   public function testParsesImpliedNameWithExplicitURL() {
-    $input = '<span class="h-card"><a href="https://example.com/" class="u-url">Some Name</a></span>';
-    $parser = new Parser($input);
-    $output = $parser->parse();
+	$input = '<span class="h-card"><a href="https://example.com/" class="u-url">Some Name</a></span>';
+	$parser = new Parser($input);
+	$output = $parser->parse();
 
-    $this->assertArrayHasKey('url', $output['items'][0]['properties']);
-    $this->assertEquals('https://example.com/', $output['items'][0]['properties']['url'][0]);
-    $this->assertEquals('Some Name', $output['items'][0]['properties']['name'][0]);
+	$this->assertArrayHasKey('url', $output['items'][0]['properties']);
+	$this->assertEquals('https://example.com/', $output['items'][0]['properties']['url'][0]);
+	$this->assertEquals('Some Name', $output['items'][0]['properties']['name'][0]);
   }
 
 	public function testMultipleImpliedHCards() {

--- a/tests/Mf2/ParseLanguageTest.php
+++ b/tests/Mf2/ParseLanguageTest.php
@@ -11,6 +11,7 @@ use Mf2;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class ParseLanguageTest extends TestCase {
+	// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
 	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
@@ -57,45 +58,45 @@ class ParseLanguageTest extends TestCase {
 		$this->assertEquals('es', $result['items'][0]['lang']);
 	} # end method testHtmlAndHEntryLang()
 
-    /**
-     * Test HTML fragment with only h-entry lang
-     */
-    public function testFragmentHEntryLangOnly()
-    {
-        $input = '<div class="h-entry" lang="en">This test is in English.</div>';
-        $parser = new Parser($input);
-        $parser->lang = true;
-        $result = $parser->parse();
+	/**
+	 * Test HTML fragment with only h-entry lang
+	 */
+	public function testFragmentHEntryLangOnly()
+	{
+		$input = '<div class="h-entry" lang="en">This test is in English.</div>';
+		$parser = new Parser($input);
+		$parser->lang = true;
+		$result = $parser->parse();
 
-        $this->assertArrayHasKey('lang', $result['items'][0]);
-        $this->assertEquals('en', $result['items'][0]['lang']);
-    } # end method testFragmentHEntryLangOnly()
+		$this->assertArrayHasKey('lang', $result['items'][0]);
+		$this->assertEquals('en', $result['items'][0]['lang']);
+	} # end method testFragmentHEntryLangOnly()
 
-    /**
-     * Test HTML fragment with no lang
-     */
-    public function testFragmentHEntryNoLang()
-    {
-        $input = '<div class="h-entry">This test is in English.</div>';
-        $parser = new Parser($input);
-        $parser->lang = true;
-        $result = $parser->parse();
+	/**
+	 * Test HTML fragment with no lang
+	 */
+	public function testFragmentHEntryNoLang()
+	{
+		$input = '<div class="h-entry">This test is in English.</div>';
+		$parser = new Parser($input);
+		$parser->lang = true;
+		$result = $parser->parse();
 
-        $this->assertArrayNotHasKey('lang', $result['items'][0]);
-    } # end method testFragmentHEntryNoLang()
+		$this->assertArrayNotHasKey('lang', $result['items'][0]);
+	} # end method testFragmentHEntryNoLang()
 
-    /**
-     * Test HTML fragment with no lang, loaded with loadXML()
-     */
-    public function testFragmentHEntryNoLangXML()
-    {
-        $input = new \DOMDocument();
-        $input->loadXML('<div class="h-entry">This test is in English.</div>');
-        $parser = new Parser($input);
-        $result = $parser->parse();
+	/**
+	 * Test HTML fragment with no lang, loaded with loadXML()
+	 */
+	public function testFragmentHEntryNoLangXML()
+	{
+		$input = new \DOMDocument();
+		$input->loadXML('<div class="h-entry">This test is in English.</div>');
+		$parser = new Parser($input);
+		$result = $parser->parse();
 
-        $this->assertArrayNotHasKey('lang', $result['items'][0]);
-    } # end method testFragmentHEntryNoLangXML()
+		$this->assertArrayNotHasKey('lang', $result['items'][0]);
+	} # end method testFragmentHEntryNoLangXML()
 
 	/**
 	 * Test with different <html lang>, h-entry lang, and h-entry without lang,

--- a/tests/Mf2/ParsePTest.php
+++ b/tests/Mf2/ParsePTest.php
@@ -12,6 +12,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 
 class ParsePTest extends TestCase {
+	// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
 	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
@@ -36,7 +37,6 @@ class ParsePTest extends TestCase {
 		$parser = new Parser($input);
 		$output = $parser->parse();
 
-
 		$this->assertArrayHasKey('name', $output['items'][0]['properties']);
 		$this->assertEquals('Example User', $output['items'][0]['properties']['name'][0]);
 	}
@@ -60,7 +60,6 @@ class ParsePTest extends TestCase {
 		$input = '<div class="h-card"><data class="p-name" value="Example User"></data></div>';
 		$parser = new Parser($input);
 		$output = $parser->parse();
-
 
 		$this->assertArrayHasKey('name', $output['items'][0]['properties']);
 		$this->assertEquals('Example User', $output['items'][0]['properties']['name'][0]);

--- a/tests/Mf2/ParseUTest.php
+++ b/tests/Mf2/ParseUTest.php
@@ -10,6 +10,7 @@ use Mf2\Parser;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class ParseUTest extends TestCase {
+	// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
 	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
@@ -31,7 +32,7 @@ class ParseUTest extends TestCase {
 	 */
 	public function testParseUHandlesEmptyHrefAttribute() {
 		$input = '<div class="h-card"><a class="u-url" href="">Awesome example website</a></div>';
-		$parser = new Parser($input, "https://example.com/");
+		$parser = new Parser($input, 'https://example.com/');
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('url', $output['items'][0]['properties']);
@@ -43,7 +44,7 @@ class ParseUTest extends TestCase {
 	 */
 	public function testParseUHandlesMissingHrefAttribute() {
 		$input = '<div class="h-card"><a class="u-url">Awesome example website</a></div>';
-		$parser = new Parser($input, "https://example.com/");
+		$parser = new Parser($input, 'https://example.com/');
 		$output = $parser->parse();
 
 		$this->assertArrayHasKey('url', $output['items'][0]['properties']);

--- a/tests/Mf2/ParseValueClassTitleTest.php
+++ b/tests/Mf2/ParseValueClassTitleTest.php
@@ -11,6 +11,7 @@ use Mf2\Parser;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class ParseValueClassTitleTest extends TestCase {
+	// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
 	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}

--- a/tests/Mf2/ParserTest.php
+++ b/tests/Mf2/ParserTest.php
@@ -20,6 +20,7 @@ class ParserTest extends TestCase {
 	use AssertIsType;
 	use AssertStringContains;
 
+	// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
 	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
@@ -930,7 +931,7 @@ EOT;
 		$this->assertEquals('Page Title', $result['items'][0]['properties']['name'][0]);
 		$this->assertEquals('A summary so the p-name won\'t be implied. This test demonstrates p-name is not being parsed.', $result['items'][0]['properties']['summary'][0]);
 	}
-	
+
 	/**
 	 * @see https://github.com/microformats/php-mf2/issues/249
 	 */

--- a/tests/Mf2/PlainTextTest.php
+++ b/tests/Mf2/PlainTextTest.php
@@ -4,74 +4,74 @@ namespace Mf2\Parser\Test;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class PlainTextTest extends TestCase {
-    /**
-     * @dataProvider aaronpkExpectations
-     */
-    public function testAaronpkExpectations($input, $pName, $eValue, $eHtml) {
-        $parser = new \Mf2\Parser($input);
-        $output = $parser->parse();
-        $entryProperties = $output['items'][0]['properties'];
-        $this->assertEquals($pName, $entryProperties['name'][0]);
-        $this->assertEquals($eValue, $entryProperties['content'][0]['value']);
-        $this->assertEquals($eHtml, $entryProperties['content'][0]['html']);
-    }
+	/**
+	 * @dataProvider aaronpkExpectations
+	 */
+	public function testAaronpkExpectations($input, $pName, $eValue, $eHtml) {
+		$parser = new \Mf2\Parser($input);
+		$output = $parser->parse();
+		$entryProperties = $output['items'][0]['properties'];
+		$this->assertEquals($pName, $entryProperties['name'][0]);
+		$this->assertEquals($eValue, $entryProperties['content'][0]['value']);
+		$this->assertEquals($eHtml, $entryProperties['content'][0]['html']);
+	}
 
-    public function aaronpkExpectations() {
-        return array(
-            1 => array(
-                "<div class=\"h-entry\">\n  <div class=\"e-content p-name\"><p>Hello World</p></div>\n</div>",
-                "Hello World",
-                "Hello World",
-                "<p>Hello World</p>"
-            ),
-            2 => array(
-                "<div class=\"h-entry\">\n  <div class=\"e-content p-name\"><p>Hello<br>World</p></div>\n</div>",
-                "Hello\nWorld",
-                "Hello\nWorld",
-                "<p>Hello<br>World</p>"
-            ),
-            3 => array(
-                "<div class=\"h-entry\">\n  <div class=\"e-content p-name\"><p>Hello<br>\nWorld</p></div>\n</div>",
-                "Hello\nWorld",
-                "Hello\nWorld",
-                "<p>Hello<br>\nWorld</p>"
-            ),
-            4 => array(
-                "<div class=\"h-entry\">\n  <div class=\"e-content p-name\">\n    <p>Hello World</p>\n  </div>\n</div>",
-                "Hello World",
-                "Hello World",
-                "<p>Hello World</p>"
-            ),
-            5 => array(
-                "<div class=\"h-entry\">\n  <div class=\"e-content p-name\">Hello\nWorld</div>\n</div>",
-                "Hello World",
-                "Hello World",
-                "Hello\nWorld"
-            ),
-            6 => array(
-                "<div class=\"h-entry\">\n  <div class=\"e-content p-name\"><p>Hello</p><p>World</p></div>\n</div>",
-                "Hello\nWorld",
-                "Hello\nWorld",
-                "<p>Hello</p><p>World</p>"
-            ),
-            7 => array(
-                "<div class=\"h-entry\">\n  <div class=\"e-content p-name\">Hello<br>\n    World</div>\n</div>",
-                "Hello\nWorld",
-                "Hello\nWorld",
-                "Hello<br>\n    World",
-            ),
-            8 => array(
-                "<div class=\"h-entry\">\n  <div class=\"e-content p-name\"><br>Hello<br>World<br></div>\n</div>",
-                "Hello\nWorld",
-                "Hello\nWorld",
-                "<br>Hello<br>World<br>"
-            ),
-            9 => array(
-                "<div class=\"h-entry\">\n  <div class=\"e-content p-name\">\n    <p>One</p>\n    <p>Two</p>\n    <p>Three</p>\n  </div>\n</div>",
-                "One\nTwo\nThree",
-                "One\nTwo\nThree",
-                "<p>One</p>\n    <p>Two</p>\n    <p>Three</p>"
-            )
-        );
-    }
+	public function aaronpkExpectations() {
+		return array(
+			1 => array(
+				"<div class=\"h-entry\">\n  <div class=\"e-content p-name\"><p>Hello World</p></div>\n</div>",
+				'Hello World',
+				'Hello World',
+				'<p>Hello World</p>'
+			),
+			2 => array(
+				"<div class=\"h-entry\">\n  <div class=\"e-content p-name\"><p>Hello<br>World</p></div>\n</div>",
+				"Hello\nWorld",
+				"Hello\nWorld",
+				'<p>Hello<br>World</p>'
+			),
+			3 => array(
+				"<div class=\"h-entry\">\n  <div class=\"e-content p-name\"><p>Hello<br>\nWorld</p></div>\n</div>",
+				"Hello\nWorld",
+				"Hello\nWorld",
+				"<p>Hello<br>\nWorld</p>"
+			),
+			4 => array(
+				"<div class=\"h-entry\">\n  <div class=\"e-content p-name\">\n    <p>Hello World</p>\n  </div>\n</div>",
+				'Hello World',
+				'Hello World',
+				'<p>Hello World</p>'
+			),
+			5 => array(
+				"<div class=\"h-entry\">\n  <div class=\"e-content p-name\">Hello\nWorld</div>\n</div>",
+				'Hello World',
+				'Hello World',
+				"Hello\nWorld"
+			),
+			6 => array(
+				"<div class=\"h-entry\">\n  <div class=\"e-content p-name\"><p>Hello</p><p>World</p></div>\n</div>",
+				"Hello\nWorld",
+				"Hello\nWorld",
+				'<p>Hello</p><p>World</p>'
+			),
+			7 => array(
+				"<div class=\"h-entry\">\n  <div class=\"e-content p-name\">Hello<br>\n    World</div>\n</div>",
+				"Hello\nWorld",
+				"Hello\nWorld",
+				"Hello<br>\n    World",
+			),
+			8 => array(
+				"<div class=\"h-entry\">\n  <div class=\"e-content p-name\"><br>Hello<br>World<br></div>\n</div>",
+				"Hello\nWorld",
+				"Hello\nWorld",
+				'<br>Hello<br>World<br>'
+			),
+			9 => array(
+				"<div class=\"h-entry\">\n  <div class=\"e-content p-name\">\n    <p>One</p>\n    <p>Two</p>\n    <p>Three</p>\n  </div>\n</div>",
+				"One\nTwo\nThree",
+				"One\nTwo\nThree",
+				"<p>One</p>\n    <p>Two</p>\n    <p>Three</p>"
+			)
+		);
+	}
 }

--- a/tests/Mf2/RelTest.php
+++ b/tests/Mf2/RelTest.php
@@ -11,60 +11,60 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class RelTest extends TestCase {
   public function testRelValueOnLinkTag() {
-    $input = '<link rel="webmention" href="https://example.com/webmention">';
-    $parser = new Parser($input);
-    $output = $parser->parse();
+	$input = '<link rel="webmention" href="https://example.com/webmention">';
+	$parser = new Parser($input);
+	$output = $parser->parse();
 
-    $this->assertArrayHasKey('webmention', $output['rels']);
-    $this->assertEquals('https://example.com/webmention', $output['rels']['webmention'][0]);
+	$this->assertArrayHasKey('webmention', $output['rels']);
+	$this->assertEquals('https://example.com/webmention', $output['rels']['webmention'][0]);
   }
 
   public function testRelValueOnATag() {
-    $input = '<a rel="webmention" href="https://example.com/webmention">webmention me</a>';
-    $parser = new Parser($input);
-    $output = $parser->parse();
+	$input = '<a rel="webmention" href="https://example.com/webmention">webmention me</a>';
+	$parser = new Parser($input);
+	$output = $parser->parse();
 
-    $this->assertArrayHasKey('webmention', $output['rels']);
-    $this->assertEquals('https://example.com/webmention', $output['rels']['webmention'][0]);
+	$this->assertArrayHasKey('webmention', $output['rels']);
+	$this->assertEquals('https://example.com/webmention', $output['rels']['webmention'][0]);
   }
 
   public function testRelValueOnAreaTag() {
-    $input = '<map><area rel="webmention" href="https://example.com/webmention"/></map>';
-    $parser = new Parser($input);
-    $output = $parser->parse();
+	$input = '<map><area rel="webmention" href="https://example.com/webmention"/></map>';
+	$parser = new Parser($input);
+	$output = $parser->parse();
 
-    $this->assertArrayHasKey('webmention', $output['rels']);
-    $this->assertEquals('https://example.com/webmention', $output['rels']['webmention'][0]);
+	$this->assertArrayHasKey('webmention', $output['rels']);
+	$this->assertEquals('https://example.com/webmention', $output['rels']['webmention'][0]);
   }
 
   public function testRelValueOrder() {
-    $input = '<map><area rel="webmention" href="https://example.com/area"/></map>
+	$input = '<map><area rel="webmention" href="https://example.com/area"/></map>
       <a rel="webmention" href="https://example.com/a">webmention me</a>
       <link rel="webmention" href="https://example.com/link">';
-    $parser = new Parser($input);
-    $output = $parser->parse();
+	$parser = new Parser($input);
+	$output = $parser->parse();
 
-    $this->assertArrayHasKey('webmention', $output['rels']);
-    $this->assertEquals('https://example.com/area', $output['rels']['webmention'][0]);
-    $this->assertEquals('https://example.com/a', $output['rels']['webmention'][1]);
-    $this->assertEquals('https://example.com/link', $output['rels']['webmention'][2]);
+	$this->assertArrayHasKey('webmention', $output['rels']);
+	$this->assertEquals('https://example.com/area', $output['rels']['webmention'][0]);
+	$this->assertEquals('https://example.com/a', $output['rels']['webmention'][1]);
+	$this->assertEquals('https://example.com/link', $output['rels']['webmention'][2]);
   }
 
   public function testRelValueOrder2() {
-    $input = '<map><area rel="webmention" href="https://example.com/area"/></map>
+	$input = '<map><area rel="webmention" href="https://example.com/area"/></map>
       <link rel="webmention" href="https://example.com/link">
       <a rel="webmention" href="https://example.com/a">webmention me</a>';
-    $parser = new Parser($input);
-    $output = $parser->parse();
+	$parser = new Parser($input);
+	$output = $parser->parse();
 
-    $this->assertArrayHasKey('webmention', $output['rels']);
-    $this->assertEquals('https://example.com/area', $output['rels']['webmention'][0]);
-    $this->assertEquals('https://example.com/link', $output['rels']['webmention'][1]);
-    $this->assertEquals('https://example.com/a', $output['rels']['webmention'][2]);
+	$this->assertArrayHasKey('webmention', $output['rels']);
+	$this->assertEquals('https://example.com/area', $output['rels']['webmention'][0]);
+	$this->assertEquals('https://example.com/link', $output['rels']['webmention'][1]);
+	$this->assertEquals('https://example.com/a', $output['rels']['webmention'][2]);
   }
 
   public function testRelValueOrder3() {
-    $input = '<html>
+	$input = '<html>
       <head>
         <link rel="webmention" href="https://example.com/link">
       </head>
@@ -73,25 +73,25 @@ class RelTest extends TestCase {
         <map><area rel="webmention" href="https://example.com/area"/></map>
       </body>
     </html>';
-    $parser = new Parser($input);
-    $output = $parser->parse();
+	$parser = new Parser($input);
+	$output = $parser->parse();
 
-    $this->assertArrayHasKey('webmention', $output['rels']);
-    $this->assertEquals('https://example.com/link', $output['rels']['webmention'][0]);
-    $this->assertEquals('https://example.com/a', $output['rels']['webmention'][1]);
-    $this->assertEquals('https://example.com/area', $output['rels']['webmention'][2]);
+	$this->assertArrayHasKey('webmention', $output['rels']);
+	$this->assertEquals('https://example.com/link', $output['rels']['webmention'][0]);
+	$this->assertEquals('https://example.com/a', $output['rels']['webmention'][1]);
+	$this->assertEquals('https://example.com/area', $output['rels']['webmention'][2]);
   }
 
   public function testRelValueOnBTag() {
-    $input = '<b rel="webmention" href="https://example.com/webmention">this makes no sense</b>';
-    $parser = new Parser($input);
-    $output = $parser->parse();
+	$input = '<b rel="webmention" href="https://example.com/webmention">this makes no sense</b>';
+	$parser = new Parser($input);
+	$output = $parser->parse();
 
-    $this->assertArrayNotHasKey('webmention', $output['rels']);
+	$this->assertArrayNotHasKey('webmention', $output['rels']);
   }
 
   public function testEnableAlternatesFlagTrue() {
-    $input = '<a rel="author" href="https://example.com/a">author a</a>
+	$input = '<a rel="author" href="https://example.com/a">author a</a>
 <a rel="author" href="https://example.com/b">author b</a>
 <a rel="in-reply-to" href="https://example.com/1">post 1</a>
 <a rel="in-reply-to" href="https://example.com/2">post 2</a>
@@ -99,15 +99,15 @@ class RelTest extends TestCase {
    href="https://example.com/fr"
    media="handheld"
    hreflang="fr">French mobile homepage</a>';
-    $parser = new Parser($input);
-    $parser->enableAlternates = true;
-    $output = $parser->parse();
+	$parser = new Parser($input);
+	$parser->enableAlternates = true;
+	$output = $parser->parse();
 
-    $this->assertArrayHasKey('alternates', $output);
+	$this->assertArrayHasKey('alternates', $output);
   }
 
   public function testEnableAlternatesFlagFalse() {
-    $input = '<a rel="author" href="https://example.com/a">author a</a>
+	$input = '<a rel="author" href="https://example.com/a">author a</a>
 <a rel="author" href="https://example.com/b">author b</a>
 <a rel="in-reply-to" href="https://example.com/1">post 1</a>
 <a rel="in-reply-to" href="https://example.com/2">post 2</a>
@@ -115,11 +115,11 @@ class RelTest extends TestCase {
    href="https://example.com/fr"
    media="handheld"
    hreflang="fr">French mobile homepage</a>';
-    $parser = new Parser($input);
-    $parser->enableAlternates = false;
-    $output = $parser->parse();
+	$parser = new Parser($input);
+	$parser->enableAlternates = false;
+	$output = $parser->parse();
 
-    $this->assertArrayNotHasKey('alternates', $output);
+	$this->assertArrayNotHasKey('alternates', $output);
   }
 
   /**
@@ -127,7 +127,7 @@ class RelTest extends TestCase {
    * @see https://microformats.org/wiki/microformats2-parsing#rel_parse_examples
    */
   public function testRelURLs() {
-    $input = '<a rel="author" href="https://example.com/a">author a</a>
+	$input = '<a rel="author" href="https://example.com/a">author a</a>
 <a rel="author" href="https://example.com/b">author b</a>
 <a rel="in-reply-to" href="https://example.com/1">post 1</a>
 <a rel="in-reply-to" href="https://example.com/2">post 2</a>
@@ -136,40 +136,40 @@ class RelTest extends TestCase {
    media="handheld"
    hreflang="fr">French mobile homepage</a>
 <link rel="alternate" type="application/atom+xml" href="https://example.com/articles.atom" title="Atom Feed" />';
-    $parser = new Parser($input);
-    $output = $parser->parse();
+	$parser = new Parser($input);
+	$output = $parser->parse();
 
-    $this->assertArrayHasKey('rels', $output);
-    $this->assertCount(4, $output['rels']);
-    $this->assertArrayHasKey('author', $output['rels']);
-    $this->assertArrayHasKey('in-reply-to', $output['rels']);
-    $this->assertArrayHasKey('alternate', $output['rels']);
-    $this->assertArrayHasKey('home', $output['rels']);
+	$this->assertArrayHasKey('rels', $output);
+	$this->assertCount(4, $output['rels']);
+	$this->assertArrayHasKey('author', $output['rels']);
+	$this->assertArrayHasKey('in-reply-to', $output['rels']);
+	$this->assertArrayHasKey('alternate', $output['rels']);
+	$this->assertArrayHasKey('home', $output['rels']);
 
-    $this->assertArrayHasKey('rel-urls', $output);
-    $this->assertCount(6, $output['rel-urls']);
-    $this->assertArrayHasKey('https://example.com/a', $output['rel-urls']);
-    $this->assertArrayHasKey('https://example.com/b', $output['rel-urls']);
-    $this->assertArrayHasKey('https://example.com/1', $output['rel-urls']);
-    $this->assertArrayHasKey('https://example.com/2', $output['rel-urls']);
-    $this->assertArrayHasKey('https://example.com/fr', $output['rel-urls']);
-    $this->assertArrayHasKey('https://example.com/articles.atom', $output['rel-urls']);
+	$this->assertArrayHasKey('rel-urls', $output);
+	$this->assertCount(6, $output['rel-urls']);
+	$this->assertArrayHasKey('https://example.com/a', $output['rel-urls']);
+	$this->assertArrayHasKey('https://example.com/b', $output['rel-urls']);
+	$this->assertArrayHasKey('https://example.com/1', $output['rel-urls']);
+	$this->assertArrayHasKey('https://example.com/2', $output['rel-urls']);
+	$this->assertArrayHasKey('https://example.com/fr', $output['rel-urls']);
+	$this->assertArrayHasKey('https://example.com/articles.atom', $output['rel-urls']);
 
-    $this->assertArrayHasKey('rels', $output['rel-urls']['https://example.com/a']);
-    $this->assertArrayHasKey('text', $output['rel-urls']['https://example.com/a']);
-    $this->assertArrayHasKey('rels', $output['rel-urls']['https://example.com/b']);
-    $this->assertArrayHasKey('text', $output['rel-urls']['https://example.com/b']);
-    $this->assertArrayHasKey('rels', $output['rel-urls']['https://example.com/1']);
-    $this->assertArrayHasKey('text', $output['rel-urls']['https://example.com/1']);
-    $this->assertArrayHasKey('rels', $output['rel-urls']['https://example.com/2']);
-    $this->assertArrayHasKey('text', $output['rel-urls']['https://example.com/2']);
-    $this->assertArrayHasKey('rels', $output['rel-urls']['https://example.com/fr']);
-    $this->assertArrayHasKey('text', $output['rel-urls']['https://example.com/fr']);
-    $this->assertArrayHasKey('media', $output['rel-urls']['https://example.com/fr']);
-    $this->assertArrayHasKey('hreflang', $output['rel-urls']['https://example.com/fr']);
-    $this->assertArrayHasKey('title', $output['rel-urls']['https://example.com/articles.atom']);
-    $this->assertArrayHasKey('type', $output['rel-urls']['https://example.com/articles.atom']);
-    $this->assertArrayHasKey('rels', $output['rel-urls']['https://example.com/articles.atom']);
+	$this->assertArrayHasKey('rels', $output['rel-urls']['https://example.com/a']);
+	$this->assertArrayHasKey('text', $output['rel-urls']['https://example.com/a']);
+	$this->assertArrayHasKey('rels', $output['rel-urls']['https://example.com/b']);
+	$this->assertArrayHasKey('text', $output['rel-urls']['https://example.com/b']);
+	$this->assertArrayHasKey('rels', $output['rel-urls']['https://example.com/1']);
+	$this->assertArrayHasKey('text', $output['rel-urls']['https://example.com/1']);
+	$this->assertArrayHasKey('rels', $output['rel-urls']['https://example.com/2']);
+	$this->assertArrayHasKey('text', $output['rel-urls']['https://example.com/2']);
+	$this->assertArrayHasKey('rels', $output['rel-urls']['https://example.com/fr']);
+	$this->assertArrayHasKey('text', $output['rel-urls']['https://example.com/fr']);
+	$this->assertArrayHasKey('media', $output['rel-urls']['https://example.com/fr']);
+	$this->assertArrayHasKey('hreflang', $output['rel-urls']['https://example.com/fr']);
+	$this->assertArrayHasKey('title', $output['rel-urls']['https://example.com/articles.atom']);
+	$this->assertArrayHasKey('type', $output['rel-urls']['https://example.com/articles.atom']);
+	$this->assertArrayHasKey('rels', $output['rel-urls']['https://example.com/articles.atom']);
   }
 
   /**
@@ -177,42 +177,42 @@ class RelTest extends TestCase {
    * @see https://github.com/microformats/microformats2-parsing/issues/30
    */
   public function testRelURLsRelsUniqueAndSorted() {
-    $input = '<a href="#" rel="me bookmark"></a>
+	$input = '<a href="#" rel="me bookmark"></a>
 <a href="#" rel="bookmark archived"></a>';
-    $parser = new Parser($input);
-    $output = $parser->parse();
-    $this->assertEquals($output['rel-urls']['#']['rels'], array('archived', 'bookmark', 'me'));
+	$parser = new Parser($input);
+	$output = $parser->parse();
+	$this->assertEquals($output['rel-urls']['#']['rels'], array('archived', 'bookmark', 'me'));
   }
 
   public function testRelURLsInfoMergesCorrectly() {
-    $input = '<a href="#" rel="a">This nodeValue</a>
+	$input = '<a href="#" rel="a">This nodeValue</a>
 <a href="#" rel="a" hreflang="en">Not this nodeValue</a>';
-    $parser = new Parser($input);
-    $output = $parser->parse();
-    $this->assertEquals($output['rel-urls']['#']['hreflang'], 'en');
-    $this->assertArrayNotHasKey('media', $output['rel-urls']['#']);
-    $this->assertArrayNotHasKey('title', $output['rel-urls']['#']);
-    $this->assertArrayNotHasKey('type', $output['rel-urls']['#']);
-    $this->assertEquals($output['rel-urls']['#']['text'], 'This nodeValue');
+	$parser = new Parser($input);
+	$output = $parser->parse();
+	$this->assertEquals($output['rel-urls']['#']['hreflang'], 'en');
+	$this->assertArrayNotHasKey('media', $output['rel-urls']['#']);
+	$this->assertArrayNotHasKey('title', $output['rel-urls']['#']);
+	$this->assertArrayNotHasKey('type', $output['rel-urls']['#']);
+	$this->assertEquals($output['rel-urls']['#']['text'], 'This nodeValue');
   }
 
   public function testRelURLsNoDuplicates() {
-    $input = '<a href="#a" rel="a"></a>
+	$input = '<a href="#a" rel="a"></a>
 <a href="#b" rel="a"></a>
 <a href="#a" rel="a"></a>';
-    $parser = new Parser($input);
-    $output = $parser->parse();
-    $this->assertEquals($output['rels']['a'], array('#a', '#b'));
+	$parser = new Parser($input);
+	$output = $parser->parse();
+	$this->assertEquals($output['rels']['a'], array('#a', '#b'));
   }
 
   public function testRelURLsFalsyTextVSEmpty() {
-    $input = '<a href="#a" rel="a">0</a>
+	$input = '<a href="#a" rel="a">0</a>
 <a href="#b" rel="b"></a>';
-    $parser = new Parser($input);
-    $output = $parser->parse();
-    $this->assertArrayHasKey('text', $output['rel-urls']['#a']);
-    $this->assertEquals($output['rel-urls']['#a']['text'], '0');
-    $this->assertArrayNotHasKey('text', $output['rel-urls']['#b']);
+	$parser = new Parser($input);
+	$output = $parser->parse();
+	$this->assertArrayHasKey('text', $output['rel-urls']['#a']);
+	$this->assertEquals($output['rel-urls']['#a']['text'], '0');
+	$this->assertArrayNotHasKey('text', $output['rel-urls']['#b']);
   }
 
 }

--- a/tests/Mf2/URLTest.php
+++ b/tests/Mf2/URLTest.php
@@ -10,6 +10,7 @@ use Mf2;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class URLTest extends TestCase {
+	// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
 	protected function set_up() {
 		date_default_timezone_set('Europe/London');
 	}
@@ -152,9 +153,9 @@ class URLTest extends TestCase {
 	 * @dataProvider dataProvider
 	 */
   public function testReturnsUrlIfAbsolute($assert, $base, $url, $expected) {
-    $actual = mf2\resolveUrl($base, $url);
+	$actual = mf2\resolveUrl($base, $url);
 
-    $this->assertEquals($expected, $actual, $assert);
+	$this->assertEquals($expected, $actual, $assert);
   }
 
 	public function dataProvider() {
@@ -265,29 +266,29 @@ class URLTest extends TestCase {
 		// http://tools.ietf.org/html/rfc3986#section-5.4
 
 		$rfcTests = array(
-			array("g:h", "g:h"),
-			array("g", "http://a/b/c/g"),
-			array("./g", "http://a/b/c/g"),
-			array("g/", "http://a/b/c/g/"),
-			array("/g", "http://a/g"),
-			array("//g", "http://g"),
-			array("?y", "http://a/b/c/d;p?y"),
-			array("g?y", "http://a/b/c/g?y"),
-			array("#s", "http://a/b/c/d;p?q#s"),
-			array("g#s", "http://a/b/c/g#s"),
-			array("g?y#s", "http://a/b/c/g?y#s"),
-			array(";x", "http://a/b/c/;x"),
-			array("g;x", "http://a/b/c/g;x"),
-			array("g;x?y#s", "http://a/b/c/g;x?y#s"),
-			array("", "http://a/b/c/d;p?q"),
-			array(".", "http://a/b/c/"),
-			array("./", "http://a/b/c/"),
-			array("..", "http://a/b/"),
-			array("../", "http://a/b/"),
-			array("../g", "http://a/b/g"),
-			array("../..", "http://a/"),
-			array("../../", "http://a/"),
-			array("../../g", "http://a/g")
+			array('g:h', 'g:h'),
+			array('g', 'http://a/b/c/g'),
+			array('./g', 'http://a/b/c/g'),
+			array('g/', 'http://a/b/c/g/'),
+			array('/g', 'http://a/g'),
+			array('//g', 'http://g'),
+			array('?y', 'http://a/b/c/d;p?y'),
+			array('g?y', 'http://a/b/c/g?y'),
+			array('#s', 'http://a/b/c/d;p?q#s'),
+			array('g#s', 'http://a/b/c/g#s'),
+			array('g?y#s', 'http://a/b/c/g?y#s'),
+			array(';x', 'http://a/b/c/;x'),
+			array('g;x', 'http://a/b/c/g;x'),
+			array('g;x?y#s', 'http://a/b/c/g;x?y#s'),
+			array('', 'http://a/b/c/d;p?q'),
+			array('.', 'http://a/b/c/'),
+			array('./', 'http://a/b/c/'),
+			array('..', 'http://a/b/'),
+			array('../', 'http://a/b/'),
+			array('../g', 'http://a/b/g'),
+			array('../..', 'http://a/'),
+			array('../../', 'http://a/'),
+			array('../../g', 'http://a/g')
 		);
 
 		foreach($rfcTests as $i=>$test) {


### PR DESCRIPTION
I tried to create some basic PHPCS rules that matches the current code. The idea of this PR is to work towards a PSR2 or PSR12 compatible code base for the next minor or major release.

## Summary

- Add PHPCS configuration for code style enforcement
- Rename `parse_recursive()` to `parseRecursive()` with deprecated wrapper for backwards compatibility
- Rename `test_vevent()` to `testVevent()` for PSR-1 compliance
- Add `phpcs:ignore` comments for `set_up()` methods (PHPUnit polyfill compatibility)
- Exclude `ParseDTTest.php` from camelCase rule to preserve date format method names (e.g., `testYYYY_MM_DD__HH_MM`)
- Fix whitespace and indentation issues in test files

## Test plan

- [ ] Run `./vendor/bin/phpcs` to verify no violations
- [ ] Run `./vendor/bin/phpunit tests` to verify tests still pass
- [ ] Verify `parse_recursive()` still works for backwards compatibility