### PR TITLE
fetch: Return early on error

### DIFF
--- a/Mf2/Parser.php
+++ b/Mf2/Parser.php
@@ -73,6 +73,11 @@ function fetch($url, $convertClassic = true, &$curlInfo=null) {
 		'Accept: text/html'
 	));
 	$html = curl_exec($ch);
+
+	if ($html === false) {
+		return null;
+	}
+
 	$info = $curlInfo = curl_getinfo($ch);
 	curl_close($ch);
 


### PR DESCRIPTION
If an curl fails, we would get the following warning:

    Deprecated: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated
